### PR TITLE
Fix compile on p8

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,20 @@
+#
+# Makefile
+#
+
+subdirs = lib test speed-test
+
+all: $(subdirs)
+
+.PHONY: $(subdirs)
+$(subdirs):
+	$(MAKE) -C $@
+
+test: lib
+
+speed-test: lib
+
+clean distclean:
+	@for dir in $(subdirs); do		\
+		$(MAKE) -C $$dir $@ || exit 1;	\
+        done

--- a/speed-test/cryptoperf-aead.c
+++ b/speed-test/cryptoperf-aead.c
@@ -51,7 +51,7 @@ static int cp_aead_init_test(struct cp_test *test, size_t len, int enc, int ccm)
 	unsigned char data[MAX_KEYLEN];
 	unsigned char ivrand[MAX_KEYLEN];
 	unsigned char *ivdata = NULL;
-	size_t ivlen = 0;
+	uint32_t ivlen = 0;
 
 	dbg("Initializing AEAD test %s\n", test->testname);
 	if (!test->driver_name) {
@@ -101,12 +101,12 @@ static int cp_aead_init_test(struct cp_test *test, size_t len, int enc, int ccm)
 						    test->u.aead.assoclen,
 						    TAGLEN);
 		
-	if (posix_memalign((void *)&input, PAGE_SIZE, test->u.aead.datalen)) {
+	if (posix_memalign((void *)&input, sysconf(_SC_PAGESIZE), test->u.aead.datalen)) {
 		printf(DRIVER_NAME": could not allocate input buffer for "
 		       "%s\n", test->driver_name);
 		goto out;
 	}
-	if (posix_memalign((void *)&output, PAGE_SIZE, test->u.aead.datalen)) {
+	if (posix_memalign((void *)&output, sysconf(_SC_PAGESIZE), test->u.aead.datalen)) {
 		printf(DRIVER_NAME": could not allocate output buffer for "
 		       "%s\n", test->driver_name);
 		goto out;

--- a/speed-test/cryptoperf-skcipher.c
+++ b/speed-test/cryptoperf-skcipher.c
@@ -85,7 +85,7 @@ static int cp_skcipher_init_test(struct cp_test *test, size_t len)
 	cp_read_random(ivdata, kcapi_cipher_blocksize(&test->u.skcipher.handle));
 	test->u.skcipher.iv = ivdata;
 
-	if (posix_memalign((void *)&scratchpad, PAGE_SIZE,
+	if (posix_memalign((void *)&scratchpad, sysconf(_SC_PAGESIZE),
 			   kcapi_cipher_blocksize(&test->u.skcipher.handle) * len)) {
 		printf(DRIVER_NAME": could not allocate scratchpad for "
 		       "%s\n", test->driver_name);

--- a/test/kcapi-main.c
+++ b/test/kcapi-main.c
@@ -414,7 +414,7 @@ static int cavs_sym(struct kcapi_cavs *cavs_test, uint32_t loops,
 		outbuflen = cavs_test->ctlen;
 	}
 	if (cavs_test->aligned) {
-		if (posix_memalign((void *)&outbuf, PAGE_SIZE, outbuflen))
+		if (posix_memalign((void *)&outbuf, sysconf(_SC_PAGESIZE), outbuflen))
 			goto out;
 		memset(outbuf, 0, outbuflen);
 	} else {
@@ -494,7 +494,7 @@ static int cavs_sym_stream(struct kcapi_cavs *cavs_test, uint32_t loops)
 		outbuflen = cavs_test->ctlen;
 	}
 	if (cavs_test->aligned) {
-		if (posix_memalign((void *)&outbuf, PAGE_SIZE, outbuflen))
+		if (posix_memalign((void *)&outbuf, sysconf(_SC_PAGESIZE), outbuflen))
 			goto out;
 		memset(outbuf, 0, outbuflen);
 	} else {
@@ -638,7 +638,7 @@ static int cavs_aead(struct kcapi_cavs *cavs_test, uint32_t loops,
 						 cavs_test->taglen);
 
 	if (cavs_test->aligned) {
-		if (posix_memalign((void *)&outbuf, PAGE_SIZE, outbuflen))
+		if (posix_memalign((void *)&outbuf, sysconf(_SC_PAGESIZE), outbuflen))
 			goto out;
 		memset(outbuf, 0, outbuflen);
 	} else {
@@ -785,7 +785,7 @@ static int cavs_aead_stream(struct kcapi_cavs *cavs_test, uint32_t loops)
 						 cavs_test->assoclen,
 						 cavs_test->taglen);
 	if (cavs_test->aligned) {
-		if (posix_memalign((void *)&outbuf, PAGE_SIZE, outbuflen))
+		if (posix_memalign((void *)&outbuf, sysconf(_SC_PAGESIZE), outbuflen))
 			goto out;
 		memset(outbuf, 0, outbuflen);
 	} else {
@@ -996,9 +996,9 @@ static int cavs_aead_large(int stream, uint32_t loops, int splice)
 	test.keylen = len / 2;
 
 	len = strlen(aad);
-	if (posix_memalign((void *)&test.assoc, PAGE_SIZE, (16 * PAGE_SIZE)))
+	if (posix_memalign((void *)&test.assoc, sysconf(_SC_PAGESIZE), (16 * sysconf(_SC_PAGESIZE))))
 		goto out;
-	hex2bin(aad, len, test.assoc, (PAGE_SIZE * 16));
+	hex2bin(aad, len, test.assoc, (sysconf(_SC_PAGESIZE) * 16));
 	test.assoclen = len / 2;
 
 	test.taglen = 16;
@@ -1181,7 +1181,7 @@ static int cavs_asym(struct kcapi_cavs *cavs_test, uint32_t loops,
 		return -EINVAL;
 
 	if (cavs_test->aligned) {
-		if (posix_memalign((void *)&outbuf, PAGE_SIZE, outbuflen))
+		if (posix_memalign((void *)&outbuf, sysconf(_SC_PAGESIZE), outbuflen))
 			goto out;
 		memset(outbuf, 0, outbuflen);
 	} else {
@@ -1291,10 +1291,10 @@ static int cavs_asym_stream(struct kcapi_cavs *cavs_test, uint32_t loops,
 		return -EINVAL;
 
 	if (cavs_test->aligned) {
-		if (posix_memalign((void *)&outbuf, PAGE_SIZE, outbuflen))
+		if (posix_memalign((void *)&outbuf, sysconf(_SC_PAGESIZE), outbuflen))
 			goto out;
 		memset(outbuf, 0, outbuflen);
-		if (posix_memalign((void *)&inbuf, PAGE_SIZE, inbuflen))
+		if (posix_memalign((void *)&inbuf, sysconf(_SC_PAGESIZE), inbuflen))
 			goto out;
 		memset(inbuf, 0, inbuflen);
 	} else {


### PR DESCRIPTION
Hi Stephan,

I just tried to compile your code on my Tuleta P8 (IBM System p). Somehow I did not have PAGE_SIZE defined in my header files for the user-space code. As written in the patch comment, I used sysconf(_SC_PAGESIZE) to obtain the pagesize used in my system. I did not test the change, I just fixed the compile for now.
There was another compile problem where I had to replace size_t with unit32_t to make it work.
I found it rather inconvenient to dive into the subdirs to get the whole code compiled. So I added a Makefile in the toplevel directory to simplify this a bit.

Please consider taking/testing those changes.

Thanks

Frank