### PR TITLE
Apps: fixed execution when CONFIG_CRYPTO_FIPS is disabled in kernel

### DIFF
--- a/apps/kcapi-hasher.c
+++ b/apps/kcapi-hasher.c
@@ -473,9 +473,14 @@ static int fipscheck_self(char *hash,
 
 	fipsfile = fopen("/proc/sys/crypto/fips_enabled", "r");
 	if (!fipsfile) {
-		fprintf(stderr, "Cannot open fips_enabled file: %s\n",
-			strerror(errno));
-		return -EIO;
+		if (errno == ENOENT) {
+			/* FIPS support not enabled in kernel */
+			return 0;
+		} else {
+			fprintf(stderr, "Cannot open fips_enabled file: %s\n",
+				strerror(errno));
+			return -EIO;
+		}
 	}
 
 	n = fread((void *)fipsflag, 1, 1, fipsfile);


### PR DESCRIPTION
selftest of FIPS shouldn't fail in this case; instead, act like it is disabled

Signed-off-by: Kirill Marinushkin <k.marinushkin@gmail.com>