### PR TITLE
Fix path to version.lds for out-of-tree build

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -47,7 +47,7 @@ libkcapi_la_SOURCES += lib/kcapi-rng.c
 endif
 
 libkcapi_la_CPPFLAGS = $(COMMON_CPPFLAGS) -fPIC -fvisibility=hidden
-libkcapi_la_LDFLAGS = $(COMMON_LDFLAGS) -Wl,--version-script,lib/version.lds -release $(VERSION)
+libkcapi_la_LDFLAGS = $(COMMON_LDFLAGS) -Wl,--version-script,$(top_srcdir)/lib/version.lds -release $(VERSION)
 
 SCAN_FILES = $(libkcapi_la_SOURCES)
 

--- a/m4/ac_check_api_version.m4
+++ b/m4/ac_check_api_version.m4
@@ -2,7 +2,7 @@ AC_DEFUN([AC_CHECK_API_VERSION],
 	 [AC_CHECK_PROG([TAIL], [tail], [yes])
 	  AM_CONDITIONAL([CAN_CHECK_API_VERSION], [test "x$TAIL" = "xyes" -a -n $SED])
 	  AM_COND_IF([CAN_CHECK_API_VERSION],
-         [AC_SUBST([API_VERSION], [$($SED -n 's/^LIBKCAPI_\([[0-9.]]*\) {/\1/p' lib/version.lds | tail -1)])
+         [AC_SUBST([API_VERSION], [$($SED -n 's/^LIBKCAPI_\([[0-9.]]*\) {/\1/p' ${srcdir}/lib/version.lds | tail -1)])
 	  AC_MSG_NOTICE([API version=$API_VERSION])
 	  AM_CONDITIONAL([CHECK_VERSION], [test "x$API_VERSION" != "x$VERSION"])
 	  AM_COND_IF([CHECK_VERSION], [AC_MSG_ERROR([API version != library version])])],


### PR DESCRIPTION
This commit fixes the following issue when we do an out-of-tree configure:

$ autoreconf -if ../libkcapi/
$ ../libkcapi/configure
...
/usr/bin/sed: can't read lib/version.lds: No such file or directory

It also fixes a build issue when we compile from another directory.