### PR TITLE
Bug | Fix README.md spell error

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ The `configure` script supports the following options:
 For instance, to compile the library with the `kcapi` test program and to
 install them in `/usr/`:
 ```
-$ ./configure --prefix=/usr/ --with-kcapi-test
+$ ./configure --prefix=/usr/ --enable-kcapi-test
 ```
 
 Then, run `make` to compile and `make install` to install in the folder


### PR DESCRIPTION
Great Job.
when I run configure command,I find a spell error.