### PR TITLE
lib/cryptouser.h: adapt CRYPTO_MAX_ALG_NAME for kernel version >= 4.12

### DIFF
--- a/lib/cryptouser.h
+++ b/lib/cryptouser.h
@@ -18,6 +18,8 @@
  * 51 Franklin St - Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
+#include <linux/version.h>
+
 /* Netlink configuration messages.  */
 enum {
 	CRYPTO_MSG_BASE = 0x10,
@@ -32,7 +34,12 @@ enum {
 #define CRYPTO_NR_MSGTYPES (CRYPTO_MSG_MAX + 1 - CRYPTO_MSG_BASE)
 
 #ifndef __KERNEL__
+
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,12,0)
+#define CRYPTO_MAX_ALG_NAME 128
+#else
 #define CRYPTO_MAX_ALG_NAME 64
+#endif
 #define CR_RTA(x)  ((struct rtattr*)(((char*)(x)) + NLMSG_ALIGN(sizeof(struct crypto_user_alg))))
 #endif
 


### PR DESCRIPTION
Kernel commit https://github.com/torvalds/linux/commit/f437a3f477cce
has changed this to 128 and I was referencing 128 vs 64
[ which is in my current tree ].

Maybe it makes sense to export that macro from the kernel.
But that's another story.

Signed-off-by: Alexandru Ardelean <ardeleanalex@gmail.com>