### PR TITLE
Update the bytesperop result value to account for AIO counts per test.

### DIFF
--- a/speed-test/cryptoperf-base.c
+++ b/speed-test/cryptoperf-base.c
@@ -57,6 +57,8 @@ int cp_exec_test(struct cp_test *test, unsigned int exectime, size_t len,
 	test->results.totaltime = 0;
 	test->results.rounds = 0;
 	test->results.byteperop = test->exec_test(test);
+	if (aio)
+		test->results.byteperop *= aio;
 
 	/* prime the test */
 	for (i = 0; i < 10; i++)


### PR DESCRIPTION
Previously each op was a single iov.  Now there are aio iovs per
test run.

Signed-off-by: Jonathan Cameron <Jonathan.Cameron@huawei.com>