### PR TITLE
test-invocation: Add some environment variables to select options

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -39,7 +39,8 @@ as listed in the following:
 
 All tests are collectively invoked with the `test-invocation.sh` script.
 In addition, the following tests are not integrated into the general
-test run:
+test run, but can be enabled by setting `ENABLE_FUZZ_TEST` to any value
+before running `test-invocation.sh` :
 
 * `kcapi-fuzz-test.sh`: Execute various fuzzing tests.
 

--- a/test/README.md
+++ b/test/README.md
@@ -46,5 +46,8 @@ test run:
 Bi-arch tests
 -------------
 
-To test both word sizes simultaneously, use test-invocation.sh which
+To test both word sizes simultaneously, use `test-invocation.sh` which
 compiles and executes the test cases.
+
+You can disable the 32 bit tests by explicitly setting `NO_32BIT_TEST`
+to any value before running `test-invocation.sh`.

--- a/test/test-invocation.sh
+++ b/test/test-invocation.sh
@@ -112,8 +112,9 @@ cd ..
 
 make distclean > /dev/null 2>&1
 
-# if we are on 64 bit system, test 32 bit alternative mode
-if $(uname -m | grep -q "x86_64")
+# if we are on 64 bit system, test 32 bit alternative mode,
+# except is has been disabled explicitly.
+if [ $(uname -m | grep -q "x86_64") && -z "$NO_32BIT_TEST" ]
 then
 	LDFLAGS=-m32 CFLAGS=-m32 ./configure $COMPILE_OPTS
 	make

--- a/test/test-invocation.sh
+++ b/test/test-invocation.sh
@@ -67,6 +67,17 @@ exec_test()
 		exit $ret
 	fi
 
+	# Run optionally.
+	if [ ! -z "$ENABLE_FUZZ_TEST"]
+	then
+		${DIR}/kcapi-fuzz-test.sh
+		ret=$?
+		if [ $ret -ne 0 ]
+		then
+			exit $ret
+		fi
+	fi
+
 	# Only execute on bare metal
 	if ! dmesg | grep -i Hypervisor | grep -q -i detected
 	then


### PR DESCRIPTION
I'm going to package your software for inclusion into Fedora.

As the title says, this adds two small options, which may come in handy for distribution packaging.