### PR TITLE
autotools: Generate and install pkg-config file

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -13,6 +13,8 @@ libkcapi_la_SOURCES = lib/cryptouser.h \
 
 man_MANS =
 
+pkgconfig_DATA = libkcapi.pc
+
 if DISABLE_LIB_SYM
 libkcapi_la_SOURCES +=
 else

--- a/configure.ac
+++ b/configure.ac
@@ -114,4 +114,7 @@ if test "$with_lib_kpp" = "yes"; then
   AC_DEFINE([WITH_LIB_KPP], 1, [KPP support enabled])
 fi
 
+PKG_INSTALLDIR
+AC_CONFIG_FILES([libkcapi.pc])
+
 AC_OUTPUT

--- a/libkcapi.pc.in
+++ b/libkcapi.pc.in
@@ -1,0 +1,10 @@
+prefix=@prefix@
+exec_prefix=@exec_prefix@
+libdir=@libdir@
+includedir=@includedir@
+
+Name: @PACKAGE_NAME@
+Description: Linux Kernel Crypto API User Space Interface Library
+Version: @PACKAGE_VERSION@
+Libs: -L${libdir} -lkcapi
+Cflags: -I${includedir}


### PR DESCRIPTION
This makes it easier to check for the presence and installed version of libkcapi from autotools, cmake, meson and other build-tools.