### PR TITLE
Add cryptoperf support (skcipher only) for per message ivs

### DIFF
--- a/speed-test/cryptoperf-aead.c
+++ b/speed-test/cryptoperf-aead.c
@@ -232,25 +232,29 @@ out:
 }
 
 static int cp_aead_init_enc_dflt(struct cp_test *test, size_t len,
-				 unsigned int aio)
+				 unsigned int aio,
+				 __attribute__((unused)) unsigned int iiv)
 {
 	return cp_aead_init_test(test, len, 1, 0, aio);
 }
 
 static int cp_aead_init_enc_ccm(struct cp_test *test, size_t len,
-				unsigned int aio)
+				unsigned int aio,
+				__attribute__((unused)) unsigned int iiv)
 {
 	return cp_aead_init_test(test, len, 1, 1, aio);
 }
 
 static int cp_aead_init_dec_dflt(struct cp_test *test, size_t len,
-				 unsigned int aio)
+				 unsigned int aio,
+				 __attribute__((unused)) unsigned int iiv)
 {
 	return cp_aead_init_test(test, len, 0, 0, aio);
 }
 
 static int cp_aead_init_dec_ccm(struct cp_test *test, size_t len,
-				unsigned int aio)
+				unsigned int aio,
+				__attribute__((unused)) unsigned int iiv)
 {
 	return cp_aead_init_test(test, len, 0, 1, aio);
 }

--- a/speed-test/cryptoperf-base.c
+++ b/speed-test/cryptoperf-base.c
@@ -26,11 +26,12 @@
  *	      execution time for the test.
  * @len: number of blocks to test
  * @aio: number of iovs to send. If 0, don't use aio.
+ * @iiv: use per iov iivs when in aio mode.
  *
  * result: 0 on success, error otherwise
  */
 int cp_exec_test(struct cp_test *test, unsigned int exectime, size_t len,
-		 unsigned int aio)
+		 unsigned int aio, unsigned int iiv)
 {
 	uint64_t testduration = 0;
 	uint64_t nano = 1;
@@ -44,7 +45,7 @@ int cp_exec_test(struct cp_test *test, unsigned int exectime, size_t len,
 		testduration = nano * exectime;
 
 	if (test->init_test) {
-		int ret = test->init_test(test, len, aio);
+		int ret = test->init_test(test, len, aio, iiv);
 		if (ret) {
 			printf(DRIVER_NAME": initialization for %s failed\n",
 			       test->testname);

--- a/speed-test/cryptoperf-hash.c
+++ b/speed-test/cryptoperf-hash.c
@@ -25,7 +25,8 @@
  * Synchronous symmetric ciphers
  ****************************************************************************/
 
-static int cp_hash_init_test(struct cp_test *test, size_t len, unsigned int aio)
+static int cp_hash_init_test(struct cp_test *test, size_t len, unsigned int aio,
+			     __attribute__((unused)) unsigned int iiv)
 {
 	unsigned char *scratchpad = NULL;
 #define MAX_KEYLEN 128

--- a/speed-test/cryptoperf-rng.c
+++ b/speed-test/cryptoperf-rng.c
@@ -22,7 +22,8 @@
 /****************************************************************************
  * Random Number Generators
  ****************************************************************************/
-static int cp_rng_init_test(struct cp_test *test, size_t len, unsigned int aio)
+static int cp_rng_init_test(struct cp_test *test, size_t len, unsigned int aio,
+			    __attribute((unused))unsigned int iiv)
 {
 	unsigned char *scratchpad = NULL;
 #define SEEDSIZE 64

--- a/speed-test/cryptoperf.h
+++ b/speed-test/cryptoperf.h
@@ -71,8 +71,9 @@ struct skcipher_def {
 	unsigned char *scratchpad;
 	unsigned char *iv;
 	size_t inputlen;
-	unsigned int aio;
+	unsigned int aio, iiv;
 	struct iovec *iovec;
+	struct iovec *iviovec;
 	struct kcapi_handle *handle;
 };
 
@@ -113,7 +114,8 @@ struct cp_test {
 	int enc;
 	unsigned int exectime;
 	struct cp_res results;
-	int (*init_test)(struct cp_test *test, size_t len, unsigned int aio);
+	int (*init_test)(struct cp_test *test, size_t len, unsigned int aio,
+			 unsigned int iiv);
 	unsigned int (*exec_test)(struct cp_test *test);
 	void (*fini_test)(struct cp_test *test);
 
@@ -177,7 +179,7 @@ static inline void cp_zfree(void *ptr, unsigned int len)
  */
 char *cp_print_status(struct cp_test *test, int raw);
 int cp_exec_test(struct cp_test *test, unsigned int exectime, size_t len,
-		 unsigned int aio);
+		 unsigned int aio, unsigned int iiv);
 int cp_read_random(unsigned char *buf, size_t buflen);
 
 #define ARRAY_SIZE(x) (sizeof(x) / sizeof((x)[0]))


### PR DESCRIPTION
Adds the -i --iiv options to control the use of this new
facility.

This is far from neat and tidy or feature complete, but might save you some time plus expresses
that this is useful - at least for me!

Signed-off-by: Jonathan Cameron <Jonathan.Cameron@huawei.com>