### PR TITLE
kcapi-hasher: Fix -Werror=implicit-fallthrough

### DIFF
--- a/apps/kcapi-hasher.c
+++ b/apps/kcapi-hasher.c
@@ -758,10 +758,10 @@ int main(int argc, char *argv[])
 					usage(argv[0]);
 					ret = 0;
 					goto out;
-				}
 				case 7:
 					bsd_style = 1;
 					break;
+				}
 				break;
 
 			case 'v':


### PR DESCRIPTION
Just a small fix for GCC v8.0.1.