### PR TITLE
kcapi-main: Fix a copy-paste typo

### DIFF
--- a/test/kcapi-main.c
+++ b/test/kcapi-main.c
@@ -764,7 +764,7 @@ static void usage(void)
 	fprintf(stderr, "\t\t8 for PBKDF\n");
 	fprintf(stderr, "\t\t9 for AIO symmetric cipher algorithm\n");
 	fprintf(stderr, "\t\t10 for AIO AEAD cipher algorithm\n");
-	fprintf(stderr, "\t\t10 for AIO asymmetric cipher algorithm\n");
+	fprintf(stderr, "\t\t11 for AIO asymmetric cipher algorithm\n");
 	fprintf(stderr, "\t-z --aux\tAuxiliary tests of the API\n");
 	fprintf(stderr, "\t-s --stream\tUse the stream API\n");
 	fprintf(stderr, "\t-y --largeinput\tTest long AD with AEAD cipher\n");


### PR DESCRIPTION
Just a trivial typo fix in `kcapi` usage help.