### PR TITLE
Fix zero-length mmap in kcapi-dgst and add relevant test cases

### DIFF
--- a/apps/kcapi-dgst.c
+++ b/apps/kcapi-dgst.c
@@ -104,7 +104,7 @@ static int cipher_op(struct kcapi_handle *handle, struct opt_data *opts)
 			if (ret < 0)
 				goto out;
 		}
-	} else {
+	} else if (insb.st_size) {
 		uint8_t *inmem_p;
 
 		inmem = mmap(NULL, insb.st_size, PROT_READ, MAP_SHARED,

--- a/test/kcapi-dgst-test.sh
+++ b/test/kcapi-dgst-test.sh
@@ -61,6 +61,7 @@ init_setup()
 gen_orig()
 {
 	local size=$1
+	touch $ORIGPT
 	dd if=/dev/urandom of=$ORIGPT bs=$size count=1 2>/dev/null
 }
 
@@ -204,7 +205,7 @@ test_filein_fileout()
 
 init_setup
 
-for i in 1 15 16 29 32 257 512 1023 16385 65535 65536 65537 99999 100000 100001
+for i in 0 1 15 16 29 32 257 512 1023 16385 65535 65536 65537 99999 100000 100001
 do
 	gen_orig $i
 	test_stdin_stdout $KEYFILE_128


### PR DESCRIPTION
The first commit fixes kcapi-dgst to not try to mmap an empty file. The second commit extends the kcapi-dgst testing suite with zero-size test cases to catch future bugs like this one.