### PR TITLE
Fix hashing of empty input for pre-4.9 kernels

### DIFF
--- a/lib/internal.h
+++ b/lib/internal.h
@@ -189,10 +189,12 @@ struct kcapi_aio {
 
 struct kcapi_flags {
 	/*
-	 * New AEAD interface introduced with 4.9.0 to only require a tag
-	 * if it is required as input or output.
+	 * A flag to distinguish the new AEAD interface introduced with 4.9.0 to
+	 * only require a tag if it is required as input or output.
+	 *
+	 * Also, kernels before 4.9.0 misbehave when no data is sent for hashing.
 	 */
-	bool newtag;
+	bool ge_v4_9;
 
 	/* AF_ALG interfaces changed to process more pages concurrently. */
 	uint32_t alg_max_pages;

--- a/lib/kcapi-aead.c
+++ b/lib/kcapi-aead.c
@@ -79,7 +79,7 @@ void kcapi_aead_getdata_input(struct kcapi_handle *handle,
 		encdatalen -= handle->aead.assoclen;
 	}
 
-	l_taglen = (enc && handle->flags.newtag == true) ? 0 :
+	l_taglen = (enc && handle->flags.ge_v4_9 == true) ? 0 :
 							handle->aead.taglen;
 	/* databuffer is all between AAD buffer (if present) and tag */
 	if (encdatalen < l_taglen) {
@@ -135,7 +135,7 @@ void kcapi_aead_getdata_output(struct kcapi_handle *handle,
 	}
 
 	/* with 4.9.0 we do not have a tag for decryption */
-	if (handle->flags.newtag == true)
+	if (handle->flags.ge_v4_9 == true)
 		l_taglen = (enc) ? handle->aead.taglen : 0;
 	else
 		l_taglen = handle->aead.taglen;
@@ -392,7 +392,7 @@ uint32_t kcapi_aead_inbuflen_enc(struct kcapi_handle *handle,
 {
 	uint32_t len = inlen + assoclen;
 
-	if (!handle->flags.newtag == true)
+	if (!handle->flags.ge_v4_9 == true)
 		len += taglen;
 
 	return len;
@@ -430,7 +430,7 @@ uint32_t kcapi_aead_outbuflen_dec(struct kcapi_handle *handle,
 	int bs = handle->info.blocksize;
 	uint32_t outlen = (inlen + bs - 1) / bs * bs + assoclen;
 
-	if (!handle->flags.newtag == true)
+	if (!handle->flags.ge_v4_9 == true)
 		outlen += taglen;
 
 	/* the kernel does not like zero length output buffers */

--- a/lib/kcapi-kernel-if.c
+++ b/lib/kcapi-kernel-if.c
@@ -989,8 +989,8 @@ err:
 
 static void _kcapi_handle_flags(struct kcapi_handle *handle)
 {
-	/* new memory structure for AF_ALG AEAD interface */
-	handle->flags.newtag = _kcapi_kernver_ge(handle, 4, 9, 0);
+	/* new memory structure for AF_ALG AEAD interface + fixed hashing empty input */
+	handle->flags.ge_v4_9 = _kcapi_kernver_ge(handle, 4, 9, 0);
 
 	/* older interfaces only processed 16 pages in a row */
 	handle->flags.alg_max_pages = _kcapi_kernver_ge(handle, 4, 11, 0) ?

--- a/lib/kcapi-md.c
+++ b/lib/kcapi-md.c
@@ -65,6 +65,7 @@ static inline int32_t _kcapi_md_update(struct kcapi_handle *handle,
 	if ((uint32_t)ret < len)
 		return -EIO;
 
+	handle->processed_sg += 1;
 	return 0;
 }
 
@@ -86,6 +87,10 @@ static int32_t _kcapi_md_final(struct kcapi_handle *handle,
 			    (unsigned long)len,	handle->info.hash_digestsize);
 		return -EINVAL;
 	}
+
+	/* Work around zero-sized hashing bug in pre-4.9 kernels: */
+	if (!handle->flags.ge_v4_9 && !handle->processed_sg)
+		_kcapi_md_update(handle, NULL, 0);
 
 	iov.iov_base = (void*)(uintptr_t)buffer;
 	iov.iov_len = len;


### PR DESCRIPTION
algif_hash in kernels prior to 4.9 return a wrong hash when no data is
sent. Since this fix has not been backported to older kernels, we need
to work around it in the library.

Please let me know if you prefer to have the relevant patches backported to stable instead:
[493b2ed3f7603a15ff738553384d5a4510ffeb95](https://git.kernel.org/cgit/linux/kernel/git/torvalds/linux.git/commit/?id=493b2ed3f7603a15ff738553384d5a4510ffeb95)
[a8348bca2944d397a528772f5c0ccb47a8b58af4](https://git.kernel.org/cgit/linux/kernel/git/torvalds/linux.git/commit/?id=a8348bca2944d397a528772f5c0ccb47a8b58af4)
[8acf7a106326eb94e143552de81f34308149121c](https://git.kernel.org/cgit/linux/kernel/git/torvalds/linux.git/commit/?id=8acf7a106326eb94e143552de81f34308149121c)
