### PR TITLE
Add support for Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,47 @@
+language: c
+
+sudo: required
+
+compiler:
+    - clang
+    - gcc
+
+addons:
+    apt:
+        packages:
+            - pkg-config
+            - realpath
+            - gcc-multilib
+            - openssl
+            - cppcheck
+            - xmlto
+            - docbook-utils
+
+install:
+    # We need a recent cppcheck because the one shipped with trusty has bugs:
+    - mkdir deps
+    - git clone 'https://github.com/danmar/cppcheck/' deps/cppcheck
+    - cd deps/cppcheck
+    - git checkout 1.82
+    - CPPCHECK_CONFIG="SRCDIR=build CFGDIR=/usr/local/share/cppcheck/cfg HAVE_RULES=yes CXXFLAGS='-O2 -DNDEBUG -Wall -Wno-sign-compare -Wno-unused-function'"
+    - eval make -j`nproc --all` $CPPCHECK_CONFIG
+    - eval sudo make install $CPPCHECK_CONFIG
+    - cd -
+
+script:
+    - autoreconf -i && OK_AUTOCONF=y
+    - >
+        [ "$OK_AUTOCONF" = y ] && ./configure \
+            --enable-kcapi-hasher \
+            --enable-kcapi-test \
+            --enable-kcapi-rngapp \
+            --enable-kcapi-encapp \
+            --enable-kcapi-dgstapp \
+            --enable-lib-asym \
+            --enable-lib-kpp && OK_CONFIGURE=y
+    - >
+        [ "$OK_CONFIGURE" = y ] && make -j`nproc --all`
+    - >
+        [ "$OK_CONFIGURE" = y ] && make cppcheck
+    - >
+        [ "$OK_CONFIGURE" = y ] && cd test && bash ./test-invocation.sh

--- a/Makefile.am
+++ b/Makefile.am
@@ -24,6 +24,7 @@ man_MANS =
 
 DOC_TARGETS =
 
+pkgconfigdir=$(libdir)/pkgconfig
 pkgconfig_DATA = libkcapi.pc
 
 if DISABLE_LIB_SYM

--- a/Makefile.am
+++ b/Makefile.am
@@ -222,7 +222,7 @@ $(lib_doc_bin_docproc_OBJECTS) : CFLAGS = $(CFLAGS_FOR_BUILD)
 $(lib_doc_bin_docproc_OBJECTS) : CPPFLAGS = $(COMMON_CPPFLAGS) $(CPPFLAGS_FOR_BUILD)
 
 lib/doc/bin/docproc${EXEEXT}: $(lib_doc_bin_docproc_OBJECTS)
-	$(CC_FOR_BUILD) $(COMMON_CPPFLAGS) $(CPPFLAGS) $(CFLAGS) -o $@ $<
+	$(CC_FOR_BUILD) $(COMMON_CPPFLAGS) $(CPPFLAGS_FOR_BUILD) $(CFLAGS_FOR_BUILD) -o $@ $<
 
 %.xml: %.tmpl lib/doc/bin/docproc$(EXEEXT)
 	$(SED) "s/@@LIBVERSION@@/$(VERSION)/" < $< > $(DOCPROC_TEMP)

--- a/Makefile.am
+++ b/Makefile.am
@@ -208,7 +208,7 @@ endif
 
 if HAVE_CPPCHECK
 cppcheck:
-	$(CPPCHECK) --enable=performance,warning,portability $(sort $(SCAN_FILES))
+	$(CPPCHECK) --error-exitcode=42 --enable=performance,warning,portability $(sort $(SCAN_FILES))
 endif
 
 if HAVE_MKTEMP

--- a/configure.ac
+++ b/configure.ac
@@ -69,10 +69,9 @@ CFLAGS="-Werror -fstack-protector-strong"
 AC_MSG_CHECKING([whether CC supports -fstack-protector-strong])
 AC_LINK_IFELSE([AC_LANG_PROGRAM([])],
 	[AC_MSG_RESULT([yes])]
-	AM_CFLAGS=-fstack-protector-strong,
-	[AC_MSG_RESULT([no])])
-CFLAGS="$my_cflags"
-AC_SUBST([AM_CFLAGS])
+	CFLAGS="-fstack-protector-strong $my_cflags",
+	[AC_MSG_RESULT([no])]
+	CFLAGS="$my_cflags")
 AX_ADD_FORTIFY_SOURCE
 
 AC_CHECK_API_VERSION

--- a/lib/kcapi-kernel-if.c
+++ b/lib/kcapi-kernel-if.c
@@ -1004,6 +1004,8 @@ int _kcapi_allocated_handle_init(struct kcapi_handle *handle, const char *type,
 	int ret;
 	char versionbuffer[50];
 
+	memset(handle, 0, sizeof(*handle));
+
 	kcapi_versionstring(versionbuffer, sizeof(versionbuffer));
 	kcapi_dolog(KCAPI_LOG_VERBOSE,
 		    "%s - initializing cipher operation with kernel",

--- a/lib/kcapi-md.c
+++ b/lib/kcapi-md.c
@@ -133,7 +133,7 @@ static inline int32_t kcapi_md_conv_common(const char *name,
 					   const uint8_t *in, uint32_t inlen,
 					   uint8_t *out, uint32_t outlen)
 {
-	struct kcapi_handle handle = { 0 };
+	struct kcapi_handle handle;
 	int32_t ret = _kcapi_allocated_handle_init(&handle, "hash", name, 0);
 
 	if (ret)

--- a/lib/kcapi-rng.c
+++ b/lib/kcapi-rng.c
@@ -150,7 +150,7 @@ static int get_random(uint8_t *buf, uint32_t buflen)
 DSO_PUBLIC
 int32_t kcapi_rng_get_bytes(uint8_t *buffer, uint32_t outlen)
 {
-	struct kcapi_handle handle = { 0 };
+	struct kcapi_handle handle;
 	uint8_t buf[KCAPI_RNG_BUFSIZE] __aligned(KCAPI_APP_ALIGN);
 	uint8_t *seedbuf = buf;
 	uint32_t seedsize = 0, orig_outlen = outlen;

--- a/lib/kcapi-sym.c
+++ b/lib/kcapi-sym.c
@@ -211,7 +211,7 @@ static inline int32_t kcapi_cipher_conv_enc_common(const char *name,
 					const uint8_t *iv,
 					uint8_t *out, uint32_t outlen)
 {
-	struct kcapi_handle handle = { 0 };
+	struct kcapi_handle handle;
 	int32_t ret = _kcapi_allocated_handle_init(&handle, "skcipher", name,
 						   0);
 

--- a/test/hasher-test.sh
+++ b/test/hasher-test.sh
@@ -147,3 +147,5 @@ done
 
 echo "==================================================================="
 echo "Number of failures: $failures"
+
+exit $failures

--- a/test/kcapi-convenience.sh
+++ b/test/kcapi-convenience.sh
@@ -33,3 +33,5 @@ fi
 
 echo "==================================================================="
 echo "Number of failures: $failures"
+
+exit $failures

--- a/test/kcapi-dgst-test.sh
+++ b/test/kcapi-dgst-test.sh
@@ -220,3 +220,5 @@ done
 
 echo "==================================================================="
 echo "Number of failures: $failures"
+
+exit $failures

--- a/test/kcapi-enc-test-large.sh
+++ b/test/kcapi-enc-test-large.sh
@@ -38,3 +38,5 @@ fi
 
 echo "==================================================================="
 echo "Number of failures: $failures"
+
+exit $failures

--- a/test/kcapi-enc-test.sh
+++ b/test/kcapi-enc-test.sh
@@ -338,3 +338,5 @@ done
 
 echo "==================================================================="
 echo "Number of failures: $failures"
+
+exit $failures

--- a/test/kcapi-enc-test.sh
+++ b/test/kcapi-enc-test.sh
@@ -66,7 +66,7 @@ bin2hex_noaad()
 	local origfile=$1
 	local aadlenskip=$2
 
-	local hex=$(od --endian=big -A n -v -t x2 -w512 -j$aadlenskip $origfile | sed 's/ //g')
+	local hex=$(hexdump -ve '/1 "%02x"' -s$aadlenskip $origfile)
 
 	echo $hex
 }

--- a/test/kcapi-fuzz-test.sh
+++ b/test/kcapi-fuzz-test.sh
@@ -59,3 +59,5 @@ fi
 
 echo "==================================================================="
 echo "Number of failures: $failures"
+
+exit $failures

--- a/test/test.sh
+++ b/test/test.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #
 # Copyright (C) 2014 - 2017, Stephan Mueller <smueller@chronox.de>
 #


### PR DESCRIPTION
This PR prepares the repository for automated testing using [Travis CI](https://travis-ci.org/), which is integrated in GutHub and can be enabled for free for public projects. The PR also fixes a couple of minor issues that prevented testing in the Travis environment properly.

The Travis script builds the code and runs `test/test-invocation.sh`.

Final steps needed to enable Travis for libkcapi:
1. Go to https://travis-ci.org/ and log in using GitHub.
2. Go to your profile page and enable this repository.

Travis will then automatically perform build, cppcheck, and tests on the latest version whenever changes are pushed to a branch, indicating pass/failure in the commit log on GitHub. It will also automatically test new pull requests.