### PR TITLE
Improve kcapi-hasher tests

### DIFF
--- a/apps/kcapi-hasher.c
+++ b/apps/kcapi-hasher.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2015 - 2018, Stephan Mueller <smueller@chronox.de>
+ * Copyright (C) 2018, Red Hat, Inc. All rights reserved.
  *
  * License: see LICENSE file in root directory
  *
@@ -60,10 +61,32 @@
 
 #include "app-internal.h"
 
+struct hash_name {
+	const char *kcapiname;
+	const char *bsdname;
+};
+
+const struct hash_name NAMES_MD5[2] = {
+	{ "md5", "MD5" }, { "hmac(md5)", "HMAC(MD5)" }
+};
+const struct hash_name NAMES_SHA1[2] = {
+	{ "sha1", "SHA1" }, { "hmac(sha1)", "HMAC(SHA1)" }
+};
+const struct hash_name NAMES_SHA224[2] = {
+	{ "sha224", "SHA224" }, { "hmac(sha224)", "HMAC(SHA224)" }
+};
+const struct hash_name NAMES_SHA256[2] = {
+	{ "sha256", "SHA256" }, { "hmac(sha256)", "HMAC(SHA256)" }
+};
+const struct hash_name NAMES_SHA384[2] = {
+	{ "sha384", "SHA384" }, { "hmac(sha384)", "HMAC(SHA384)" }
+};
+const struct hash_name NAMES_SHA512[2] = {
+	{ "sha512", "SHA512" }, { "hmac(sha512)", "HMAC(SHA512)" }
+};
+
 static uint8_t fipscheck_hmackey[] = "orboDeJITITejsirpADONivirpUkvarP";
 static uint8_t hmaccalc_hmackey[] = "FIPS-FTW-RHT2009";
-
-static char *bsdhashname;
 
 static void usage(char *name)
 {
@@ -94,7 +117,7 @@ static void version(char *name)
 
 static int hasher(struct kcapi_handle *handle, char *filename,
 		  const char *comphash, uint32_t comphashlen,
-		  FILE *outfile)
+		  const char *bsdhashname, FILE *outfile)
 {	
 	int fd = -1;
 	int ret = 0;
@@ -228,7 +251,8 @@ static char *get_hmac_file(char *filename)
 	return checkfile;
 }
 
-static int hash_files(char *hashname, char *filename[], uint32_t files,
+static int hash_files(const char *hashname, const char *bsdhashname,
+		      char *filename[], uint32_t files,
 		      const uint8_t *hmackey, uint32_t hmackeylen,
 		      int fipshmac)
 {
@@ -273,14 +297,14 @@ static int hash_files(char *hashname, char *filename[], uint32_t files,
 				}
 				free(outfile);
 			}
-			ret = hasher(handle, filename[i], NULL, 0, out);
+			ret = hasher(handle, filename[i], NULL, 0, bsdhashname, out);
 			if (fipshmac)
 				fclose(out);
 			if (ret)
 				break;
 		}
 	} else {
-		ret = hasher(handle, NULL, NULL, 0, stdout);
+		ret = hasher(handle, NULL, NULL, 0, bsdhashname, stdout);
 	}
 
 	kcapi_md_destroy(handle);
@@ -290,8 +314,8 @@ static int hash_files(char *hashname, char *filename[], uint32_t files,
 #define CHK_QUIET (1)
 #define CHK_STATUS (2)
 
-static int process_checkfile(char *hashname, char *checkfile, char *targetfile,
-			     int log,
+static int process_checkfile(const char *hashname,  const char *bsdhashname,
+			     char *checkfile, char *targetfile, int log,
 			     const uint8_t *hmackey, uint32_t hmackeylen)
 {
 	FILE *file = NULL;
@@ -408,7 +432,8 @@ static int process_checkfile(char *hashname, char *checkfile, char *targetfile,
 			while (isblank(*filename) && isprint(*filename))
 				filename++;
 
-			r = hasher(handle, filename, hexhash, hashlen, stdout);
+			r = hasher(handle, filename, hexhash, hashlen,
+				   bsdhashname, stdout);
 
 			if (r == 0) {
 				if (log < CHK_QUIET)
@@ -427,7 +452,8 @@ static int process_checkfile(char *hashname, char *checkfile, char *targetfile,
 			 */
 			if (targetfile) {
 				ret = hasher(handle, targetfile,
-					     hexhash, hashlen + 1, stdout);
+					     hexhash, hashlen + 1,
+					     bsdhashname, stdout);
 				goto out;
 			}
 		}
@@ -441,20 +467,7 @@ out:
 
 }
 
-static int get_hmac_cipherstring(char *hash, uint32_t hashlen)
-{
-	char *tmpbuf = strdup(hash);
-
-	if (!tmpbuf) {
-		fprintf(stderr, "Cannot allocate memory for HMAC key\n");
-			return -ENOMEM;
-	}
-	snprintf(hash, hashlen, "hmac(%s)", tmpbuf);
-	free(tmpbuf);
-	return 0;
-}
-
-static int fipscheck_self(char *hash,
+static int fipscheck_self(const char *hash,
 			  const uint8_t *hmackey, uint32_t hmackeylen)
 {
 	char *checkfile = NULL;
@@ -516,8 +529,8 @@ static int fipscheck_self(char *hash,
 		goto out;
 	}
 
-	ret = process_checkfile(hash, checkfile, selfname, CHK_STATUS,
-				hmackey, hmackeylen);
+	ret = process_checkfile(hash, NULL, checkfile, selfname,
+				CHK_STATUS, hmackey, hmackeylen);
 	if (ret)
 		goto out;
 
@@ -551,7 +564,7 @@ static int fipscheck_self(char *hash,
 		goto out;
 	}
 
-	ret = process_checkfile(hash, checkfile, selfname, CHK_STATUS,
+	ret = process_checkfile(hash, NULL, checkfile, selfname, CHK_STATUS,
 				hmackey, hmackeylen);
 
 out:
@@ -562,10 +575,11 @@ out:
 
 int main(int argc, char *argv[])
 {
+	const struct hash_name *names;
+	const char *hash;
+	const char *bsdhash;
 	char *basec = NULL;
-        char *basen = NULL;
-#define HASHNAMESIZE 13
-	char hash[(HASHNAMESIZE + 1)];
+	char *basen = NULL;
 	int ret = -EFAULT;
 
 	char *checkfile = NULL;
@@ -573,6 +587,7 @@ int main(int argc, char *argv[])
 	uint8_t *hmackey = NULL;
 	uint32_t hmackeylen = 0;
 	int loglevel = 0;
+	int hmac = 0;
 	int fipscheck = 0;
 	int fipshmac = 0;
 	int bsd_style = 0;
@@ -586,7 +601,7 @@ int main(int argc, char *argv[])
 	 */
 	uint8_t *check_hmackey = fipscheck_hmackey;
 	uint32_t check_hmackeylen = strlen((char *)fipscheck_hmackey);
-	char check_hash[(HASHNAMESIZE + 1)];
+	const char *check_hash;
 
 	static struct option opts[] =
 	{
@@ -609,77 +624,69 @@ int main(int argc, char *argv[])
 	}
 	basen = basename(basec);
 
-	memset(hash, 0, sizeof(hash));
-	memset(check_hash, 0, sizeof(check_hash));
-	strncpy(check_hash, "hmac(sha256)", HASHNAMESIZE);
+	check_hash = "hmac(sha256)";
 	if (0 == strncmp(basen, "sha256sum", 9)) {
-		strncpy(hash, "sha256", HASHNAMESIZE);
-		bsdhashname = "SHA256";
+		names = NAMES_SHA256;
 	} else if (0 == strncmp(basen, "sha512sum", 9)) {
-		strncpy(hash, "sha512", HASHNAMESIZE);
-		bsdhashname = "SHA512";
+		names = NAMES_SHA512;
 	} else if (0 == strncmp(basen, "sha1sum", 7)) {
-		strncpy(hash, "sha1", HASHNAMESIZE);
-		bsdhashname = "SHA1";
+		names = NAMES_SHA1;
 	} else if (0 == strncmp(basen, "sha224sum", 9)) {
-		strncpy(hash, "sha224", HASHNAMESIZE);
-		bsdhashname = "SHA224";
+		names = NAMES_SHA224;
 	} else if (0 == strncmp(basen, "sha384sum", 9)) {
-		strncpy(hash, "sha384", HASHNAMESIZE);
-		bsdhashname = "SHA384";
+		names = NAMES_SHA384;
 	} else if (0 == strncmp(basen, "md5sum", 6)) {
-		strncpy(hash, "md5", HASHNAMESIZE);
-		bsdhashname = "MD5";
+		names = NAMES_MD5;
 	} else if (0 == strncmp(basen, "fipshmac", 8)) {
-		strncpy(hash, "hmac(sha256)", HASHNAMESIZE);
-		bsdhashname = "HMAC(SHA256)";
+		names = NAMES_SHA256;
+		hmac = 1;
 		hmackey = fipscheck_hmackey;
 		hmackeylen = strlen((char *)fipscheck_hmackey);
 		fipshmac = 1;
 	} else if (0 == strncmp(basen, "fipscheck", 9)) {
-		strncpy(hash, "hmac(sha256)", HASHNAMESIZE);
-		bsdhashname = "HMAC(SHA256)";
+		names = NAMES_SHA256;
+		hmac = 1;
 		hmackey = fipscheck_hmackey;
 		hmackeylen = strlen((char *)fipscheck_hmackey);
 		fipscheck = 1;
 	} else if (0 == strncmp(basen, "sha1hmac", 8)) {
-		strncpy(hash, "hmac(sha1)", HASHNAMESIZE);
-		bsdhashname = "HMAC(SHA1)";
+		names = NAMES_SHA1;
+		hmac = 1;
 		hmackey = hmaccalc_hmackey;
 		hmackeylen = strlen((char *)hmaccalc_hmackey);
-		strncpy(check_hash, "hmac(sha512)", HASHNAMESIZE);
+		check_hash = "hmac(sha512)";
 		check_hmackey = hmaccalc_hmackey;
 		check_hmackeylen = strlen((char *)hmaccalc_hmackey);
 	} else if (0 == strncmp(basen, "sha224hmac", 10)) {
-		strncpy(hash, "hmac(sha224)", HASHNAMESIZE);
-		bsdhashname = "HMAC(SHA224)";
+		names = NAMES_SHA224;
+		hmac = 1;
 		hmackey = hmaccalc_hmackey;
 		hmackeylen = strlen((char *)hmaccalc_hmackey);
-		strncpy(check_hash, "hmac(sha512)", HASHNAMESIZE);
+		check_hash = "hmac(sha512)";
 		check_hmackey = hmaccalc_hmackey;
 		check_hmackeylen = strlen((char *)hmaccalc_hmackey);
 	} else if (0 == strncmp(basen, "sha256hmac", 10)) {
-		strncpy(hash, "hmac(sha256)", HASHNAMESIZE);
-		bsdhashname = "HMAC(SHA256)";
+		names = NAMES_SHA256;
+		hmac = 1;
 		hmackey = hmaccalc_hmackey;
 		hmackeylen = strlen((char *)hmaccalc_hmackey);
-		strncpy(check_hash, "hmac(sha512)", HASHNAMESIZE);
+		check_hash = "hmac(sha512)";
 		check_hmackey = hmaccalc_hmackey;
 		check_hmackeylen = strlen((char *)hmaccalc_hmackey);
 	} else if (0 == strncmp(basen, "sha384hmac", 10)) {
-		strncpy(hash, "hmac(sha384)", HASHNAMESIZE);
-		bsdhashname = "HMAC(SHA384)";
+		names = NAMES_SHA384;
+		hmac = 1;
 		hmackey = hmaccalc_hmackey;
 		hmackeylen = strlen((char *)hmaccalc_hmackey);
-		strncpy(check_hash, "hmac(sha512)", HASHNAMESIZE);
+		check_hash = "hmac(sha512)";
 		check_hmackey = hmaccalc_hmackey;
 		check_hmackeylen = strlen((char *)hmaccalc_hmackey);
 	} else if (0 == strncmp(basen, "sha512hmac", 10)) {
-		strncpy(hash, "hmac(sha512)", HASHNAMESIZE);
-		bsdhashname = "HMAC(SHA512)";
+		names = NAMES_SHA512;
+		hmac = 1;
 		hmackey = hmaccalc_hmackey;
 		hmackeylen = strlen((char *)hmaccalc_hmackey);
-		strncpy(check_hash, "hmac(sha512)", HASHNAMESIZE);
+		check_hash = "hmac(sha512)";
 		check_hmackey = hmaccalc_hmackey;
 		check_hmackeylen = strlen((char *)hmaccalc_hmackey);
 	} else {
@@ -733,9 +740,7 @@ int main(int argc, char *argv[])
 						fprintf(stderr, "Cannot allocate memory for HMAC key\n");
 						goto out;
 					}
-					if (get_hmac_cipherstring(hash,
-							HASHNAMESIZE))
-						goto out;
+					hmac = 1;
 					break;
 				case 5:
 					if (hmackey &&
@@ -752,9 +757,7 @@ int main(int argc, char *argv[])
 						goto out;
 					}
 					hmackeylen = strlen(optarg);
-					if (get_hmac_cipherstring(hash,
-								HASHNAMESIZE))
-						goto out;
+					hmac = 1;
 					break;
 				case 6:
 					usage(argv[0]);
@@ -803,8 +806,7 @@ int main(int argc, char *argv[])
 					fprintf(stderr, "Cannot allocate memory for HMAC key\n");
 					goto out;
 				}
-				if (get_hmac_cipherstring(hash, HASHNAMESIZE))
-					goto out;
+				hmac = 1;
 				break;
 			case 'b':
 				if (hmackey && hmackey != fipscheck_hmackey &&
@@ -820,17 +822,13 @@ int main(int argc, char *argv[])
 					goto out;
 				}
 				hmackeylen = strlen(optarg);
-				if (get_hmac_cipherstring(hash, HASHNAMESIZE))
-					goto out;
+				hmac = 1;
 				break;
 			default:
 				usage(argv[0]);
 				goto out;
 		}
 	}
-
-	if (!bsd_style)
-		bsdhashname = NULL;
 
 	if (fipscheck_self(check_hash, check_hmackey, check_hmackeylen)) {
 		fprintf(stderr, "Integrity check of application %s failed\n",
@@ -852,17 +850,21 @@ int main(int argc, char *argv[])
 			goto out;
 		optind++;
 	}
-	
+
+	hash = names[hmac].kcapiname;
+	bsdhash = bsd_style ? names[hmac].bsdname : NULL;
+
 	if (checkfile) {
-		ret = process_checkfile(hash, checkfile, targetfile, loglevel,
-					hmackey, hmackeylen);
+		ret = process_checkfile(hash, bsdhash, checkfile, targetfile,
+					loglevel, hmackey, hmackeylen);
 		if (ret)
 			goto out;
 	} else if (optind == argc)
-		ret = hash_files(hash, NULL, 0, hmackey, hmackeylen, fipshmac);
+		ret = hash_files(hash, bsdhash, NULL, 0, hmackey, hmackeylen,
+				 fipshmac);
 
 	if (optind < argc)
-		ret = hash_files(hash, argv + optind, (argc - optind),
+		ret = hash_files(hash, bsdhash, argv + optind, (argc - optind),
 				 hmackey, hmackeylen, fipshmac);
 
 

--- a/apps/kcapi-hasher.c
+++ b/apps/kcapi-hasher.c
@@ -320,6 +320,7 @@ static int process_checkfile(const char *hashname,  const char *bsdhashname,
 {
 	FILE *file = NULL;
 	int ret = 0;
+	int checked_any = 0;
 	struct kcapi_handle *handle;
 
 	/*
@@ -457,13 +458,20 @@ static int process_checkfile(const char *hashname,  const char *bsdhashname,
 				goto out;
 			}
 		}
+
+		checked_any = 1;
 	}
 
 out:
 	if (file)
 		fclose(file);
 	kcapi_md_destroy(handle);
-	return ret;
+
+	/*
+	 * If we found no lines to check, return an error.
+	 * (See https://pagure.io/hmaccalc/c/1afb99549816192eb8e6bc8101bc417c2ffa764c)
+	 */
+	return checked_any ? ret : 1;
 
 }
 

--- a/apps/kcapi-hasher.c
+++ b/apps/kcapi-hasher.c
@@ -397,7 +397,8 @@ static int process_checkfile(char *hashname, char *checkfile, char *targetfile,
 
 		if (!hexhash || !hashlen) {
 			printf("Hash not found\n");
-			return 1;
+			ret = 1;
+			goto out;
 		}
 
 		if (filename) {
@@ -425,8 +426,9 @@ static int process_checkfile(char *hashname, char *checkfile, char *targetfile,
 			 * file
 			 */
 			if (targetfile) {
-				return hasher(handle, targetfile,
-					      hexhash, hashlen + 1, stdout);
+				ret = hasher(handle, targetfile,
+					     hexhash, hashlen + 1, stdout);
+				goto out;
 			}
 		}
 	}

--- a/test/hasher-test.sh
+++ b/test/hasher-test.sh
@@ -48,6 +48,29 @@ done
 libdir=$(dirname $(realpath ../.libs/libkcapi.so))
 libname=$(realpath ../.libs/libkcapi.so)
 
+for hasher in $SUMHASHER $HMACHASHER
+do
+	>$CHKFILE
+	LD_LIBRARY_PATH=$libdir LD_PRELOAD=$libname $hasher -c $CHKFILE
+	if [ $? -eq 0 ]
+	then
+		echo_fail "Verification of empty checker file with hasher $hasher did not fail"
+	else
+		echo_pass "Failure on empty checker file for $hasher"
+	fi
+
+	echo >$CHKFILE
+	LD_LIBRARY_PATH=$libdir LD_PRELOAD=$libname $hasher -c $CHKFILE
+	if [ $? -eq 0 ]
+	then
+		echo_fail "Verification of empty line checker file with hasher $hasher did not fail"
+	else
+		echo_pass "Failure on empty line checker file for $hasher"
+	fi
+
+	rm -f $CHKFILE
+done
+
 for i in $SUMHASHER
 do
 	hash=$(basename $i)

--- a/test/hasher-test.sh
+++ b/test/hasher-test.sh
@@ -145,6 +145,82 @@ do
 	rm -f $CHKFILE
 done
 
+#
+# hmaccalc known-answer tests from RFC 2202 and 4231
+#
+
+function expand_string() {
+	if [[ "$1" == 0x* ]]
+	then
+		printf "$(echo -n "${1#0x}" | sed 's/\(..\)/\\x\1/g')"
+	else
+		echo -n "$1"
+	fi
+}
+
+function run_kat() {
+	hasher="$1"; shift
+	id="$1"; shift
+	key="$1"; shift
+	data="$1"; shift
+	result="$1"; shift
+
+	keyhex="$(expand_string "$key" | hexdump -ve '/1 "%02x"')"
+
+	expand_string "$data" >"$ANOTHER"
+	echo "${result#0x}  $ANOTHER" >"$CHKFILE"
+
+	LD_LIBRARY_PATH=$libdir LD_PRELOAD=$libname "${TMPDIR}/$hasher" -q -k "$keyhex" -c "$CHKFILE"
+	if [ $? -ne 0 ]
+	then
+		echo_fail "Verification of hasher $hasher -c ... with KAT '$id' failed"
+	else
+		echo_pass "Verification of hasher $hasher -c ... with KAT '$id'"
+	fi
+
+	LD_LIBRARY_PATH=$libdir LD_PRELOAD=$libname "${TMPDIR}/$hasher" -q -k "$keyhex" "$ANOTHER" | \
+		diff - "$CHKFILE"
+	if [ $? -ne 0 ]
+	then
+		echo_fail "Verification of hasher $hasher output with KAT '$id' failed"
+	else
+		echo_pass "Verification of hasher $hasher output with KAT '$id'"
+	fi
+}
+
+for suffix in sum hmac
+do
+	run_kat sha1$suffix   "RFC 2202, section 3, #1"   0x0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b "Hi There" 0xb617318655057264e28bc0b6fb378c8ef146be00
+	run_kat sha1$suffix   "RFC 2202, section 3, #2"   "Jefe" "what do ya want for nothing?" 0xeffcdf6ae5eb2fa2d27416d5f184df9c259a7c79
+	run_kat sha1$suffix   "RFC 2202, section 3, #3"   0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa 0xdddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd 0x125d7342b9ac11cd91a39af48aa17b4f63f175d3
+	run_kat sha1$suffix   "RFC 2202, section 3, #4"   0x0102030405060708090a0b0c0d0e0f10111213141516171819 0xcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcd 0x4c9007f4026250c6bc8414f9bf50c86c2d7235da
+	run_kat sha1$suffix   "RFC 2202, section 3, #5"   0x0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c "Test With Truncation" 0x4c1a03424b55e07fe7f27be1d58bb9324a9a5a04
+	run_kat sha1$suffix   "RFC 2202, section 3, #6"   0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa "Test Using Larger Than Block-Size Key - Hash Key First" 0xaa4ae5e15272d00e95705637ce8a3b55ed402112
+	run_kat sha1$suffix   "RFC 2202, section 3, #7"   0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa "Test Using Larger Than Block-Size Key and Larger Than One Block-Size Data" 0xe8e99d0f45237d786d6bbaa7965c7808bbff1a91
+	run_kat sha256$suffix "RFC 4231, section 4.2, #1" 0x0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b "Hi There" 0xb0344c61d8db38535ca8afceaf0bf12b881dc200c9833da726e9376c2e32cff7
+	run_kat sha384$suffix "RFC 4231, section 4.2, #2" 0x0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b "Hi There" 0xafd03944d84895626b0825f4ab46907f15f9dadbe4101ec682aa034c7cebc59cfaea9ea9076ede7f4af152e8b2fa9cb6
+	run_kat sha512$suffix "RFC 4231, section 4.2, #3" 0x0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b "Hi There" 0x87aa7cdea5ef619d4ff0b4241a1d6cb02379f4e2ce4ec2787ad0b30545e17cdedaa833b7d6b8a702038b274eaea3f4e4be9d914eeb61f1702e696c203a126854
+	run_kat sha256$suffix "RFC 4231, section 4.3, #1" "Jefe" "what do ya want for nothing?" 0x5bdcc146bf60754e6a042426089575c75a003f089d2739839dec58b964ec3843
+	run_kat sha384$suffix "RFC 4231, section 4.3, #2" "Jefe" "what do ya want for nothing?" 0xaf45d2e376484031617f78d2b58a6b1b9c7ef464f5a01b47e42ec3736322445e8e2240ca5e69e2c78b3239ecfab21649
+	run_kat sha512$suffix "RFC 4231, section 4.3, #3" "Jefe" "what do ya want for nothing?" 0x164b7a7bfcf819e2e395fbe73b56e0a387bd64222e831fd610270cd7ea2505549758bf75c05a994a6d034f65f8f0e6fdcaeab1a34d4a6b4b636e070a38bce737
+	run_kat sha256$suffix "RFC 4231, section 4.4, #1" 0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa 0xdddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd 0x773ea91e36800e46854db8ebd09181a72959098b3ef8c122d9635514ced565fe
+	run_kat sha384$suffix "RFC 4231, section 4.4, #2" 0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa 0xdddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd 0x88062608d3e6ad8a0aa2ace014c8a86f0aa635d947ac9febe83ef4e55966144b2a5ab39dc13814b94e3ab6e101a34f27
+	run_kat sha512$suffix "RFC 4231, section 4.4, #3" 0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa 0xdddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd 0xfa73b0089d56a284efb0f0756c890be9b1b5dbdd8ee81a3655f83e33b2279d39bf3e848279a722c806b485a47e67c807b946a337bee8942674278859e13292fb
+	run_kat sha256$suffix "RFC 4231, section 4.5, #1" 0x0102030405060708090a0b0c0d0e0f10111213141516171819 0xcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcd 0x82558a389a443c0ea4cc819899f2083a85f0faa3e578f8077a2e3ff46729665b
+	run_kat sha384$suffix "RFC 4231, section 4.5, #2" 0x0102030405060708090a0b0c0d0e0f10111213141516171819 0xcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcd 0x3e8a69b7783c25851933ab6290af6ca77a9981480850009cc5577c6e1f573b4e6801dd23c4a7d679ccf8a386c674cffb
+	run_kat sha512$suffix "RFC 4231, section 4.5, #3" 0x0102030405060708090a0b0c0d0e0f10111213141516171819 0xcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcd 0xb0ba465637458c6990e5a8c5f61d4af7e576d97ff94b872de76f8050361ee3dba91ca5c11aa25eb4d679275cc5788063a5f19741120c4f2de2adebeb10a298dd
+	# Do not run truncated tests (truncated tags are not supported):
+	#run_kat sha256$suffix "RFC 4231, section 4.6, #1" 0x0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c 0x546573742057697468205472756e636174696f6e 0xa3b6167473100ee06e0c796c2955552b
+	#run_kat sha384$suffix "RFC 4231, section 4.6, #2" 0x0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c 0x546573742057697468205472756e636174696f6e 0x3abf34c3503b2a23a46efc619baef897
+	#run_kat sha512$suffix "RFC 4231, section 4.6, #3" 0x0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c 0x546573742057697468205472756e636174696f6e 0x415fad6271580a531d4179bc891d87a6
+	run_kat sha256$suffix "RFC 4231, section 4.7, #1" 0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa 0x54657374205573696e67204c6172676572205468616e20426c6f636b2d53697a65204b6579202d2048617368204b6579204669727374 0x60e431591ee0b67f0d8a26aacbf5b77f8e0bc6213728c5140546040f0ee37f54
+	run_kat sha384$suffix "RFC 4231, section 4.7, #2" 0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa 0x54657374205573696e67204c6172676572205468616e20426c6f636b2d53697a65204b6579202d2048617368204b6579204669727374 0x4ece084485813e9088d2c63a041bc5b44f9ef1012a2b588f3cd11f05033ac4c60c2ef6ab4030fe8296248df163f44952
+	run_kat sha512$suffix "RFC 4231, section 4.7, #3" 0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa 0x54657374205573696e67204c6172676572205468616e20426c6f636b2d53697a65204b6579202d2048617368204b6579204669727374 0x80b24263c7c1a3ebb71493c1dd7be8b49b46d1f41b4aeec1121b013783f8f3526b56d037e05f2598bd0fd2215d6a1e5295e64f73f63f0aec8b915a985d786598
+	run_kat sha256$suffix "RFC 4231, section 4.8, #1" 0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa 0x5468697320697320612074657374207573696e672061206c6172676572207468616e20626c6f636b2d73697a65206b657920616e642061206c6172676572207468616e20626c6f636b2d73697a6520646174612e20546865206b6579206e6565647320746f20626520686173686564206265666f7265206265696e6720757365642062792074686520484d414320616c676f726974686d2e 0x9b09ffa71b942fcb27635fbcd5b0e944bfdc63644f0713938a7f51535c3a35e2
+	run_kat sha384$suffix "RFC 4231, section 4.8, #2" 0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa 0x5468697320697320612074657374207573696e672061206c6172676572207468616e20626c6f636b2d73697a65206b657920616e642061206c6172676572207468616e20626c6f636b2d73697a6520646174612e20546865206b6579206e6565647320746f20626520686173686564206265666f7265206265696e6720757365642062792074686520484d414320616c676f726974686d2e 0x6617178e941f020d351e2f254e8fd32c602420feb0b8fb9adccebb82461e99c5a678cc31e799176d3860e6110c46523e
+	run_kat sha512$suffix "RFC 4231, section 4.8, #3" 0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa 0x5468697320697320612074657374207573696e672061206c6172676572207468616e20626c6f636b2d73697a65206b657920616e642061206c6172676572207468616e20626c6f636b2d73697a6520646174612e20546865206b6579206e6565647320746f20626520686173686564206265666f7265206265696e6720757365642062792074686520484d414320616c676f726974686d2e 0xe37b6a775dc87dbaa4dfa9f96e5e3ffddebd71f8867289865df5a32d20cdc944b6022cac3c4982b10d5eeb55c3e4de15134676fb6de0446065c97440fa8c6a58
+done
+
 echo "==================================================================="
 echo "Number of failures: $failures"
 


### PR DESCRIPTION
This PR has three main parts:
1. The first commit fixes a few potential resource leaks in error handling found while going over the code. There may be more such bugs elsewhere, I didn't have time to search for all of them.
2. The 3rd commit adds testing of kcapi-hasher against RFC vectors (as a sanity check). The 2nd commit fixes kcapi-hasher so that the -k and -b options work correctly when used with the *hmac tools (this is a prerequisite for the 3rd commit). This commit involves a slight refactoring of the hash name handling (it is still a bit clumsy, feel free to rewrite it in a better way).
3. The 4th commit fixes kcapi-hasher to exit with error when the passed check file is empty. Not failing in this case may cause checks to silently pass in situations where the existence of a check file implies that a certain file *must* be checked. The 5th commit adds a regression test for such case.