### PR TITLE
kcapi-enc: Fix unpadding for large files

### DIFF
--- a/apps/kcapi-enc.c
+++ b/apps/kcapi-enc.c
@@ -667,7 +667,7 @@ static int cipher_op(struct kcapi_handle *handle, struct opt_data *opts)
 				goto out;
 
 			ret = return_data(handle, opts, outfd, outsize,
-					  generated_bytes, 1);
+					  generated_bytes, outsize == avail);
 			if (ret < 0)
 				goto out;
 


### PR DESCRIPTION
Try to remove padding only at the last chunk.

Fixes issue #43.