### PR TITLE
Fix some static checker warnings

### DIFF
--- a/apps/app-internal.c
+++ b/apps/app-internal.c
@@ -33,7 +33,7 @@
 #include "app-internal.h"
 
 static unsigned int verbosity = KCAPI_LOG_NONE;
-char appname[16];
+static char appname[16];
 
 static uint8_t hex_char(unsigned int bin, int u)
 {

--- a/apps/kcapi-hasher.c
+++ b/apps/kcapi-hasher.c
@@ -66,22 +66,22 @@ struct hash_name {
 	const char *bsdname;
 };
 
-const struct hash_name NAMES_MD5[2] = {
+static const struct hash_name NAMES_MD5[2] = {
 	{ "md5", "MD5" }, { "hmac(md5)", "HMAC(MD5)" }
 };
-const struct hash_name NAMES_SHA1[2] = {
+static const struct hash_name NAMES_SHA1[2] = {
 	{ "sha1", "SHA1" }, { "hmac(sha1)", "HMAC(SHA1)" }
 };
-const struct hash_name NAMES_SHA224[2] = {
+static const struct hash_name NAMES_SHA224[2] = {
 	{ "sha224", "SHA224" }, { "hmac(sha224)", "HMAC(SHA224)" }
 };
-const struct hash_name NAMES_SHA256[2] = {
+static const struct hash_name NAMES_SHA256[2] = {
 	{ "sha256", "SHA256" }, { "hmac(sha256)", "HMAC(SHA256)" }
 };
-const struct hash_name NAMES_SHA384[2] = {
+static const struct hash_name NAMES_SHA384[2] = {
 	{ "sha384", "SHA384" }, { "hmac(sha384)", "HMAC(SHA384)" }
 };
-const struct hash_name NAMES_SHA512[2] = {
+static const struct hash_name NAMES_SHA512[2] = {
 	{ "sha512", "SHA512" }, { "hmac(sha512)", "HMAC(SHA512)" }
 };
 

--- a/apps/kcapi-rng.c
+++ b/apps/kcapi-rng.c
@@ -48,7 +48,7 @@
 static struct kcapi_handle *rng = NULL;
 static unsigned int Verbosity = KCAPI_LOG_WARN;
 static char *rng_name = NULL;
-bool hexout = false;
+static bool hexout = false;
 
 #if !defined(HAVE_GETRANDOM) && !defined(__NR_getrandom)
 static int random_fd = -1;
@@ -136,7 +136,7 @@ static void usage(void)
 	exit(1);
 }
 
-static unsigned long parse_opts(int argc, char *argv[])
+static int parse_opts(int argc, char *argv[], unsigned long *outlen)
 {
 	int c = 0;
 	char version[30];
@@ -219,7 +219,8 @@ static unsigned long parse_opts(int argc, char *argv[])
 	if (!bytes)
 		usage();
 
-	return bytes;
+	*outlen = bytes;
+	return 0;
 }
 
 int main(int argc, char *argv[])
@@ -228,7 +229,11 @@ int main(int argc, char *argv[])
 	uint8_t buf[KCAPI_RNG_BUFSIZE] __aligned(KCAPI_APP_ALIGN);
 	uint8_t *seedbuf = buf;
 	uint32_t seedsize = 0;
-	unsigned long outlen = parse_opts(argc, argv);
+	unsigned long outlen;
+
+	ret = parse_opts(argc, argv, &outlen);
+	if (ret)
+		return ret;
 
 	set_verbosity("kcapi-rng", Verbosity);
 

--- a/lib/internal.h
+++ b/lib/internal.h
@@ -232,7 +232,7 @@ struct kcapi_handle {
  * Declarations for internal functions
  ************************************************************/
 
-int kcapi_verbosity_level;
+extern int kcapi_verbosity_level;
 void kcapi_dolog(int severity, const char *fmt, ...);
 
 int32_t _kcapi_common_send_meta_fd(struct kcapi_handle *handle, int *fdptr,

--- a/speed-test/cryptoperf-main.c
+++ b/speed-test/cryptoperf-main.c
@@ -27,7 +27,7 @@ struct test_array {
 	size_t entries;
 };
 
-struct test_array tests[4];
+static struct test_array tests[4];
 
 static void print_tests(struct test_array *tests, int print)
 {


### PR DESCRIPTION
This patch fixes several warnings reported by QtCreator (which probably
uses some CLang plugin).