### PR TITLE
kcapi-hasher: Fix buffer overrun in get_hmac_file

### DIFF
--- a/apps/kcapi-hasher.c
+++ b/apps/kcapi-hasher.c
@@ -360,7 +360,7 @@ static char *get_hmac_file(const char *filename)
 		fprintf(stderr, "File too long\n");
 		return NULL;
 	}
-	checkfile = malloc(filelen + prefixlen + 1 + suffixlen);
+	checkfile = malloc(filelen + prefixlen + 1 + suffixlen + 1);
 	if (!checkfile)
 		return NULL;
 


### PR DESCRIPTION
We need to allocate space also for the terminating null character...