### PR TITLE
Allow configuring single directory for .hmac files

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -147,18 +147,23 @@ hasher_links = $(hasher_links_fc) $(hasher_links_hc)
 CHECKSUM_CMD_FC = $(OPENSSL) sha256 -r -hmac orboDeJITITejsirpADONivirpUkvarP
 CHECKSUM_CMD_HC = $(OPENSSL) sha512 -r -hmac FIPS-FTW-RHT2009
 
+CHECK_DIR_BIN = $(if $(CHECK_DIR),$(CHECK_DIR),$(bindir))
+CHECK_DIR_LIB = $(if $(CHECK_DIR),$(CHECK_DIR),$(libdir))
+
 install-exec-hook:
 	(cd $(DESTDIR)$(bindir) && \
 	($(foreach link, $(hasher_links), $(LN) -f kcapi-hasher $(link);)))
 	-rm -f $(DESTDIR)$(bindir)/kcapi-hasher
 if HAVE_OPENSSL
+	$(MKDIR_P) $(DESTDIR)$(CHECK_DIR_BIN)
+	$(MKDIR_P) $(DESTDIR)$(CHECK_DIR_LIB)
 	(cd $(DESTDIR)$(bindir) && \
 	($(foreach link, $(hasher_links_fc), \
-		$(CHECKSUM_CMD_FC) $(link) > $(CHECK_PREFIX)$(link).$(CHECK_SUFFIX);) \
+		$(CHECKSUM_CMD_FC) $(link) > $(DESTDIR)$(CHECK_DIR_BIN)/$(CHECK_PREFIX)$(link).$(CHECK_SUFFIX);) \
 	$(foreach link, $(hasher_links_hc), \
-		$(CHECKSUM_CMD_HC) $(link) > $(CHECK_PREFIX)$(link).$(CHECK_SUFFIX);):))
+		$(CHECKSUM_CMD_HC) $(link) > $(DESTDIR)$(CHECK_DIR_BIN)/$(CHECK_PREFIX)$(link).$(CHECK_SUFFIX);):))
 	($(foreach lib, $(wildcard $(DESTDIR)$(libdir)/libkcapi.so*), \
-		$(CHECKSUM_CMD_FC) $(lib)  > $(CHECK_PREFIX)$(lib).$(CHECK_SUFFIX);):)
+		$(CHECKSUM_CMD_FC) $(lib)  > $(DESTDIR)$(CHECK_DIR_LIB)/$(CHECK_PREFIX)$(notdir $(lib)).$(CHECK_SUFFIX);):)
 endif
 endif
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -147,21 +147,22 @@ hasher_links = $(hasher_links_fc) $(hasher_links_hc)
 CHECKSUM_CMD_FC = $(OPENSSL) sha256 -r -hmac orboDeJITITejsirpADONivirpUkvarP
 CHECKSUM_CMD_HC = $(OPENSSL) sha512 -r -hmac FIPS-FTW-RHT2009
 
-CHECK_DIR_BIN = $(if $(CHECK_DIR),$(CHECK_DIR),$(bindir))
-CHECK_DIR_LIB = $(if $(CHECK_DIR),$(CHECK_DIR),$(libdir))
+CHECK_DIR_LIB = $(if $(CHECK_DIR),$(CHECK_DIR)/fipscheck,$(libdir))
+CHECK_DIR_BIN_FC = $(if $(CHECK_DIR),$(CHECK_DIR)/fipscheck,$(bindir))
+CHECK_DIR_BIN_HC = $(if $(CHECK_DIR),$(CHECK_DIR)/hmaccalc,$(bindir))
 
 install-exec-hook:
 	(cd $(DESTDIR)$(bindir) && \
 	($(foreach link, $(hasher_links), $(LN) -f kcapi-hasher $(link);)))
 	-rm -f $(DESTDIR)$(bindir)/kcapi-hasher
 if HAVE_OPENSSL
-	$(MKDIR_P) $(DESTDIR)$(CHECK_DIR_BIN)
-	$(MKDIR_P) $(DESTDIR)$(CHECK_DIR_LIB)
+	$(MKDIR_P) $(DESTDIR)$(CHECK_DIR_BIN_FC)
+	$(MKDIR_P) $(DESTDIR)$(CHECK_DIR_BIN_HC)
 	(cd $(DESTDIR)$(bindir) && \
 	($(foreach link, $(hasher_links_fc), \
-		$(CHECKSUM_CMD_FC) $(link) > $(DESTDIR)$(CHECK_DIR_BIN)/$(CHECK_PREFIX)$(link).$(CHECK_SUFFIX);) \
+		$(CHECKSUM_CMD_FC) $(link) > $(DESTDIR)$(CHECK_DIR_BIN_FC)/$(CHECK_PREFIX)$(link).$(CHECK_SUFFIX);) \
 	$(foreach link, $(hasher_links_hc), \
-		$(CHECKSUM_CMD_HC) $(link) > $(DESTDIR)$(CHECK_DIR_BIN)/$(CHECK_PREFIX)$(link).$(CHECK_SUFFIX);):))
+		$(CHECKSUM_CMD_HC) $(link) > $(DESTDIR)$(CHECK_DIR_BIN_HC)/$(CHECK_PREFIX)$(link).$(CHECK_SUFFIX);):))
 	($(foreach lib, $(wildcard $(DESTDIR)$(libdir)/libkcapi.so*), \
 		$(CHECKSUM_CMD_FC) $(lib)  > $(DESTDIR)$(CHECK_DIR_LIB)/$(CHECK_PREFIX)$(notdir $(lib)).$(CHECK_SUFFIX);):)
 endif

--- a/configure.ac
+++ b/configure.ac
@@ -130,7 +130,7 @@ AC_ARG_ENABLE([sum-prefix],
 	      fi
 	      ,CHECK_PREFIX=)
 
-AC_ARG_ENABLE(sum-suffix,
+AC_ARG_ENABLE([sum-suffix],
 	      AS_HELP_STRING([--enable-sum-suffix=EXT],[suffix to add to filenames when deriving the binary's checksum file's name (default "hmac")]),
 	      if test x$enableval != xno ; then
 		  CHECK_SUFFIX="$enableval"
@@ -139,11 +139,24 @@ AC_ARG_ENABLE(sum-suffix,
 	      fi
 	      ,CHECK_SUFFIX=hmac)
 
+AC_ARG_ENABLE([sum-dir],
+	      AS_HELP_STRING([--enable-sum-dir=DIR],[directory where HMAC checksum files will be placed (default: place alongside binaries)]),
+	      if test x$enableval != xno ; then
+		  CHECK_DIR="$enableval"
+	      else
+		  CHECK_DIR=
+	      fi
+	      ,CHECK_DIR=)
+
 AC_SUBST(CHECK_PREFIX)
 AC_SUBST(CHECK_SUFFIX)
+AC_SUBST(CHECK_DIR)
 
 AC_DEFINE_UNQUOTED(CHECK_PREFIX,"$CHECK_PREFIX",[Define to the prefix which contains the hmac for a binary.])
 AC_DEFINE_UNQUOTED(CHECK_SUFFIX,"$CHECK_SUFFIX",[Define to the suffix which contains the hmac for a binary.])
+AS_IF([test "x$CHECK_DIR" != "x"], [
+	AC_DEFINE_UNQUOTED(CHECK_DIR,"$CHECK_DIR",[Define to the directory which contains the hmac for a binary.])
+])
 
 PKG_INSTALLDIR
 if test "x$pkgconfigdir" = "x"; then


### PR DESCRIPTION
Since it is not desirable to have non-executable files in $(bindir),
allow configuring a single directory for storing the self-check hmac
files, as it is done by the original hmaccalc and fipscheck projects.