### PR TITLE
Fix getrandom call in kcapi-rng.c

### DIFF
--- a/lib/kcapi-rng.c
+++ b/lib/kcapi-rng.c
@@ -18,6 +18,8 @@
  * DAMAGE.
  */
 
+#define _GNU_SOURCE
+#include <unistd.h>
 #include <linux/random.h>
 #ifdef HAVE_GETRANDOM
 #include <sys/random.h>


### PR DESCRIPTION
_GNU_SOURCE must be defined and unistd.h must be included to be able to
use getrandom

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>