### PR TITLE
kcapi-hasher: Fix command-line parsing

### DIFF
--- a/apps/kcapi-hasher.c
+++ b/apps/kcapi-hasher.c
@@ -841,10 +841,12 @@ int main(int argc, char *argv[])
 	}
 	basen = basename(basec);
 
+	opterr = 0;
 	if (getopt_long(argc, argv, opts_name_short, opts_name, &opt_index) == 'n')
 		basen = optarg;
 	else
-		opt_index = 0;
+		optind = 1;
+	opterr = 1;
 
 	params_self = &PARAMS_SELF_FIPSCHECK;
 	if (0 == strncmp(basen, "sha256sum", 9)) {


### PR DESCRIPTION
I made a mistake in commit 3be3e18d4a2e ("kcapi-hasher: Allow picking
basename via cmdline"), which apparently broke command-line parsing when
the '-n' options is not used. This patch fixes the issue by resetting
the right variable and also silences error messages when checking for
the '-n' option.

Fedora BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1599831