### PR TITLE
Fix GCC v8.1 warnings for strncpy (v2)

### DIFF
--- a/apps/kcapi-hasher.c
+++ b/apps/kcapi-hasher.c
@@ -61,6 +61,10 @@
 
 #include "app-internal.h"
 
+#define GCC_VERSION (__GNUC__ * 10000 \
+			+ __GNUC_MINOR__ * 100 \
+			+ __GNUC_PATCHLEVEL__)
+
 struct hash_name {
 	const char *kcapiname;
 	const char *bsdname;
@@ -341,6 +345,17 @@ out:
 	return ret;
 }
 
+/*
+ * GCC v8.1.0 introduced -Wstringop-truncation but it is not smart enough to
+ * find that cursor string will be NULL-terminated after all paste() calls and
+ * warns with:
+ * error: 'strncpy' destination unchanged after copying no bytes [-Werror=stringop-truncation]
+ * error: 'strncpy' output truncated before terminating nul copying 5 bytes from a string of the same length [-Werror=stringop-truncation]
+ */
+#pragma GCC diagnostic push
+#if GCC_VERSION >= 80100
+#pragma GCC diagnostic ignored "-Wstringop-truncation"
+#endif
 static char *paste(char *dst, const char *src, size_t size)
 {
 	strncpy(dst, src, size);
@@ -398,6 +413,7 @@ static char *get_hmac_file(const char *filename, const char *subdir)
 	strncpy(cursor, "\0", 1);
 	return checkfile;
 }
+#pragma GCC diagnostic pop /* -Wstringop-truncation */
 
 static int hash_files(const struct hash_params *params,
 		      char *filenames[], uint32_t files,

--- a/lib/kcapi-kernel-if.c
+++ b/lib/kcapi-kernel-if.c
@@ -627,9 +627,9 @@ static int __kcapi_common_getinfo(struct kcapi_handle *handle,
 
 	if (drivername)
 		strncpy(req.cru.cru_driver_name, ciphername,
-			strlen(ciphername));
+			sizeof(req.cru.cru_driver_name) - 1);
 	else
-		strncpy(req.cru.cru_name, ciphername, strlen(ciphername));
+		strncpy(req.cru.cru_name, ciphername, sizeof(req.cru.cru_name) - 1);
 
 	/* talk to netlink socket */
 	sd =  socket(AF_NETLINK, SOCK_RAW, NETLINK_CRYPTO);

--- a/test/kcapi-main.c
+++ b/test/kcapi-main.c
@@ -3121,7 +3121,7 @@ int main(int argc, char *argv[])
 				break;
 			case 'c':
 				strncpy(cavs_test.cipher, optarg,
-					CIPHERMAXNAME);
+					CIPHERMAXNAME - 1);
 				break;
 			case 'p':
 				len = strlen(optarg);


### PR DESCRIPTION
New Yocto/OpenEmbedded uses GCC v8.1.0 (with -Werror). Fix or mask any -Werror=stringop-truncation errors to get clean compilation.

---
Changes since v1:
1. use GCC_VERSION macro so the warning flag will be ignored on clang and older GCC.