### PR TITLE
configure.ac: Fix variable assignment

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -160,7 +160,7 @@ AS_IF([test "x$CHECK_DIR" != "x"], [
 
 PKG_INSTALLDIR
 if test "x$pkgconfigdir" = "x"; then
-  pkgconfigdir = "${libdir}/pkgconfig"
+  pkgconfigdir="${libdir}/pkgconfig"
 fi
 AC_SUBST([pkgconfigdir], [$pkgconfigdir])
 


### PR DESCRIPTION
Shell variable assignment must be without spaces around '=', otherwise
it is interpreted as a command invocation:

    ./configure: line 14207: pkgconfigdir: command not found