### PR TITLE
CI: Use newer Xenial environment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: c
 
 sudo: required
+dist: xenial
 
 matrix:
     include:


### PR DESCRIPTION
This will run tests on a newer kernel (4.15+), increasing test coverage
(mainly support for asynchronous operations).