### PR TITLE
speed-test: Fix potential memory leak

### DIFF
--- a/speed-test/cryptoperf-main.c
+++ b/speed-test/cryptoperf-main.c
@@ -203,6 +203,7 @@ int main(int argc, char *argv[])
 					print_tests(&tests[i], 1);
 				return 0;
 			case 'c':
+				free(cipher);
 				cipher = strndup(optarg, 50);
 				break;
 			case 't':
@@ -244,7 +245,6 @@ int main(int argc, char *argv[])
 	ret = exec_subset_test(cipher, raw, &test_params);
 
 out:
-	if (cipher)
-		free(cipher);
+	free(cipher);
 	return ret;
 }


### PR DESCRIPTION
We need to free the old cipher when assigning it, just in case someone
specifies '-c ...' more than once. Reproducible with:

    valgrind bin/kcapi-speed -c 'ctr(aes)' -c 'ctr(aes)'

While there, also remove the unnecessary check for NULL before calling
free() in the cleanup section.

Signed-off-by: Ondrej Mosnacek <omosnace@redhat.com>