### PR TITLE
kcapi-main: fix fork() return code handling

### DIFF
--- a/test/kcapi-main.c
+++ b/test/kcapi-main.c
@@ -894,9 +894,11 @@ static void mt_sym_writer(struct kcapi_handle *handle, struct iovec *iov,
 		pid_t pid;
 
 		pid = fork();
-		if (!pid)
+		if (pid)
+			/* parent - return and continue */
 			return;
 
+		/* child - write the data and exit */
 		sleep(1);
 	}
 


### PR DESCRIPTION
The logic was inverted, which lead to a race condition because the main
process (actually the child) didn't wait for the writer process when
wait() was called later (the child had no children...).