### PR TITLE
Disable use of __NR_io_getevents when not defined

### DIFF
--- a/lib/internal.h
+++ b/lib/internal.h
@@ -325,10 +325,17 @@ static inline int io_submit(aio_context_t ctx, long n,  struct iocb **iocb)
     return syscall(__NR_io_submit, ctx, n, iocb);
 }
 
-static inline int io_getevents(aio_context_t ctx, long min, long max,
-            struct io_event *events, struct timespec *timeout)
+static inline int io_getevents(__attribute__((unused)) aio_context_t ctx,
+            __attribute__((unused)) long min,
+            __attribute__((unused)) long max,
+            __attribute__((unused)) struct io_event *events,
+            __attribute__((unused)) struct timespec *timeout)
 {
+#ifdef __NR_io_getevents
     return syscall(__NR_io_getevents, ctx, min, max, events, timeout);
+#else
+    return -ENOSYS;
+#endif
 }
 
 /************************************************************


### PR DESCRIPTION
Architectures like riscv32 do not define this syscall, therefore return
ENOSYS on such architectures

Upstream-Status: Pending
Signed-off-by: Khem Raj <raj.khem@gmail.com>