### PR TITLE
kcapi-enc: fix fwrite() handling

### DIFF
--- a/apps/kcapi-enc.c
+++ b/apps/kcapi-enc.c
@@ -114,14 +114,12 @@ static int return_data_stdout(struct kcapi_handle *handle,
 		}
 
 		/* write the data */
-		if ((outlen = fwrite(tmpbufptr, sizeof(char), outlen,
-				     stdout)) != 0) {
-			outsize -= inlen;
-		} else {
+		if (fwrite(tmpbufptr, sizeof(char), outlen, stdout) != outlen) {
 			dolog(KCAPI_LOG_ERR, "Write failed %d", -errno);
 			ret = -errno;
 			goto out;
 		}
+		outsize -= inlen;
 	}
 
 	/*


### PR DESCRIPTION
clang 11's static analysis reports:
```
  CCSA   apps/kcapi-enc.plist
apps/kcapi-enc.c:117:8: warning: Although the value stored to 'outlen' is used in the enclosing expression, the value is never actually read from 'outlen' [deadcode.DeadStores]
                if ((outlen = fwrite(tmpbufptr, sizeof(char), outlen,
                     ^        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
1 warning generated.
```

Indeed the outlen variable is not used after assingment and there is
another issue - the return value should be compared against outlen to
make sure that all data has been written. Fix both issues and
restructure the conditional to be easier to read.