### PR TITLE
kcapi: Fix hang in fuzz tests with recent kernels

### DIFF
--- a/test/kcapi-main.c
+++ b/test/kcapi-main.c
@@ -380,7 +380,7 @@ static int fuzz_cipher(struct kcapi_cavs *cavs_test, unsigned long flags,
 	}
 
 	for (i = 0; i < sizeof(indata); i++) {
-		unsigned int outlen = sizeof(outdata);
+		unsigned int outlen = i;
 		uint8_t *out = outdata;
 		uint8_t *iv = indata;
 		uint8_t *in = indata;
@@ -474,7 +474,7 @@ static int fuzz_aead(struct kcapi_cavs *cavs_test, unsigned long flags,
 	}
 
 	for (i = 0; i < sizeof(indata); i++) {
-		unsigned int outlen = sizeof(outdata);
+		unsigned int outlen = i;
 		uint8_t *out = outdata;
 		uint8_t *iv = indata;
 		uint8_t *in = indata;


### PR DESCRIPTION
After kernel commit f3c802a1f300 ("crypto: algif_aead - Only wake up
when..."), the fuzz tests hang indefinitely, because they request more
output data than the operation can produce. Fix this by requesting at
most the expected size of the output data.