### PR TITLE
Fix bad types in _kcapi_common_send_meta()

### DIFF
--- a/lib/kcapi-kernel-if.c
+++ b/lib/kcapi-kernel-if.c
@@ -125,7 +125,7 @@ ssize_t _kcapi_common_send_meta(struct kcapi_handle *handle,
 
 	/* plaintext / ciphertext data */
 	struct cmsghdr *header = NULL;
-	size_t *type = NULL;
+	uint32_t *type = NULL;
 	struct msghdr msg;
 
 	/* IV data */
@@ -135,7 +135,7 @@ ssize_t _kcapi_common_send_meta(struct kcapi_handle *handle,
 			  0;
 
 	/* AEAD data */
-	size_t *assoclen = NULL;
+	uint32_t *assoclen = NULL;
 	size_t assoc_msg_size = handle->aead.assoclen ?
 				CMSG_SPACE(sizeof(*assoclen)) : 0;
 
@@ -205,7 +205,7 @@ ssize_t _kcapi_common_send_meta(struct kcapi_handle *handle,
 		header->cmsg_type = ALG_SET_AEAD_ASSOCLEN;
 		header->cmsg_len = CMSG_LEN(sizeof(*assoclen));
 		assoclen = (void*)CMSG_DATA(header);
-		*assoclen = handle->aead.assoclen;
+		*assoclen = (uint32_t)handle->aead.assoclen;
 	}
 
 	ret = sendmsg(*_kcapi_get_opfd(handle), &msg, (int)flags);


### PR DESCRIPTION
The types for 'type' and 'assoclen' variables need to match the kernel
ABI, so they can't be changed to size_t. On most arches it is by chance
still working, but on s390x usign size_t here makes almost all tests
fail. Change the variables back to uint32_t pointers to fix this.