### PR TITLE
Fix builds with -flto

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -69,7 +69,7 @@ else
 libkcapi_la_SOURCES +=
 endif
 
-libkcapi_la_CPPFLAGS = $(COMMON_CPPFLAGS) -fvisibility=hidden
+libkcapi_la_CPPFLAGS = $(COMMON_CPPFLAGS)
 libkcapi_la_LDFLAGS = $(COMMON_LDFLAGS) -Wl,--version-script,$(top_srcdir)/lib/version.lds -version-number `echo $(VERSION) | sed 's/\./:/g'`
 
 SCAN_FILES = $(libkcapi_la_SOURCES)

--- a/lib/internal.h
+++ b/lib/internal.h
@@ -350,6 +350,16 @@ static inline int io_getevents(__attribute__((unused)) aio_context_t ctx,
 #if __GNUC__ >= 4
 # define DSO_PUBLIC __attribute__ ((visibility ("default")))
 
+#if __GNUC__ >= 10
+# define IMPL_SYMVER(name, version) \
+    __attribute__ ((visibility ("default"))) \
+    __attribute__((__symver__("kcapi_" #name "@@LIBKCAPI_" version)))
+
+# define ORIG_SYMVER(name, version) \
+    __attribute__ ((visibility ("default"))) \
+    __attribute__((__symver__("kcapi_" #name "@LIBKCAPI_" version)))
+
+#else
 # define IMPL_SYMVER(name, version) \
     __asm__(".global impl_" #name ";"\
 	    ".symver impl_" #name ",kcapi_" #name "@@LIBKCAPI_" version);\
@@ -359,6 +369,7 @@ static inline int io_getevents(__attribute__((unused)) aio_context_t ctx,
     __asm__(".global orig_" #name ";"\
 	    ".symver orig_" #name ",kcapi_" #name "@LIBKCAPI_" version);\
     __attribute__ ((visibility ("default")))
+#endif
 
 #else
 # error "Compiler version too old"

--- a/lib/internal.h
+++ b/lib/internal.h
@@ -347,32 +347,19 @@ static inline int io_getevents(__attribute__((unused)) aio_context_t ctx,
  * Auxiliary macros
  ************************************************************/
 
-#if __GNUC__ >= 4
-# define DSO_PUBLIC __attribute__ ((visibility ("default")))
-
 #if __GNUC__ >= 10
 # define IMPL_SYMVER(name, version) \
-    __attribute__ ((visibility ("default"))) \
     __attribute__((__symver__("kcapi_" #name "@@LIBKCAPI_" version)))
 
 # define ORIG_SYMVER(name, version) \
-    __attribute__ ((visibility ("default"))) \
     __attribute__((__symver__("kcapi_" #name "@LIBKCAPI_" version)))
 
 #else
 # define IMPL_SYMVER(name, version) \
-    __asm__(".global impl_" #name ";"\
-	    ".symver impl_" #name ",kcapi_" #name "@@LIBKCAPI_" version);\
-    __attribute__ ((visibility ("default")))
+    __asm__(".symver impl_" #name ",kcapi_" #name "@@LIBKCAPI_" version);
 
 # define ORIG_SYMVER(name, version) \
-    __asm__(".global orig_" #name ";"\
-	    ".symver orig_" #name ",kcapi_" #name "@LIBKCAPI_" version);\
-    __attribute__ ((visibility ("default")))
-#endif
-
-#else
-# error "Compiler version too old"
+    __asm__(".symver orig_" #name ",kcapi_" #name "@LIBKCAPI_" version);
 #endif
 
 #ifdef __cplusplus

--- a/lib/kcapi-aead.c
+++ b/lib/kcapi-aead.c
@@ -21,27 +21,23 @@
 #include "internal.h"
 #include "kcapi.h"
 
-DSO_PUBLIC
 int kcapi_aead_init(struct kcapi_handle **handle, const char *ciphername,
 		    uint32_t flags)
 {
 	return _kcapi_handle_init(handle, "aead", ciphername, flags);
 }
 
-DSO_PUBLIC
 void kcapi_aead_destroy(struct kcapi_handle *handle)
 {
 	_kcapi_handle_destroy(handle);
 }
 
-DSO_PUBLIC
 int kcapi_aead_setkey(struct kcapi_handle *handle,
 		      const uint8_t *key, uint32_t keylen)
 {
 	return _kcapi_common_setkey(handle, key, keylen);
 }
 
-DSO_PUBLIC
 int kcapi_aead_settaglen(struct kcapi_handle *handle, uint32_t taglen)
 {
 	struct kcapi_handle_tfm *tfm = handle->tfm;
@@ -504,7 +500,6 @@ int32_t orig_aead_stream_op(struct kcapi_handle *handle,
 	return (int32_t)impl_aead_stream_op(handle, iov, iovlen);
 }
 
-DSO_PUBLIC
 uint32_t kcapi_aead_ivsize(struct kcapi_handle *handle)
 {
 	struct kcapi_handle_tfm *tfm = handle->tfm;
@@ -512,7 +507,6 @@ uint32_t kcapi_aead_ivsize(struct kcapi_handle *handle)
 	return tfm->info.ivsize;
 }
 
-DSO_PUBLIC
 uint32_t kcapi_aead_blocksize(struct kcapi_handle *handle)
 {
 	struct kcapi_handle_tfm *tfm = handle->tfm;
@@ -520,7 +514,6 @@ uint32_t kcapi_aead_blocksize(struct kcapi_handle *handle)
 	return tfm->info.blocksize;
 }
 
-DSO_PUBLIC
 uint32_t kcapi_aead_authsize(struct kcapi_handle *handle)
 {
 	struct kcapi_handle_tfm *tfm = handle->tfm;
@@ -619,7 +612,6 @@ uint32_t orig_aead_outbuflen_dec(struct kcapi_handle *handle,
 						 taglen);
 }
 
-DSO_PUBLIC
 int kcapi_aead_ccm_nonce_to_iv(const uint8_t *nonce, uint32_t noncelen,
 			       uint8_t **iv, uint32_t *ivlen)
 {

--- a/lib/kcapi-asym.c
+++ b/lib/kcapi-asym.c
@@ -21,27 +21,23 @@
 #include "internal.h"
 #include "kcapi.h"
 
-DSO_PUBLIC
 int kcapi_akcipher_init(struct kcapi_handle **handle, const char *ciphername,
 			uint32_t flags)
 {
 	return _kcapi_handle_init(handle, "akcipher", ciphername, flags);
 }
 
-DSO_PUBLIC
 void kcapi_akcipher_destroy(struct kcapi_handle *handle)
 {
 	_kcapi_handle_destroy(handle);
 }
 
-DSO_PUBLIC
 int kcapi_akcipher_setkey(struct kcapi_handle *handle,
 			  const uint8_t *key, uint32_t keylen)
 {
 	return _kcapi_common_setkey(handle, key, keylen);
 }
 
-DSO_PUBLIC
 int kcapi_akcipher_setpubkey(struct kcapi_handle *handle,
 			     const uint8_t *key, uint32_t keylen)
 {

--- a/lib/kcapi-kdf.c
+++ b/lib/kcapi-kdf.c
@@ -454,7 +454,6 @@ static inline uint64_t kcapi_get_time(void)
 	return 0;
 }
 
-DSO_PUBLIC
 uint32_t kcapi_pbkdf_iteration_count(const char *hashname, uint64_t timeshresh)
 {
 #define LOW_ITERATION_COUNT	(UINT32_C(1<<16))

--- a/lib/kcapi-kernel-if.c
+++ b/lib/kcapi-kernel-if.c
@@ -1230,7 +1230,6 @@ err:
 	return ret;
 }
 
-DSO_PUBLIC
 int kcapi_handle_reinit(struct kcapi_handle **newhandle,
 			struct kcapi_handle *existing, uint32_t flags)
 {

--- a/lib/kcapi-kpp.c
+++ b/lib/kcapi-kpp.c
@@ -21,7 +21,6 @@
 #include "internal.h"
 #include "kcapi.h"
 
-DSO_PUBLIC
 int kcapi_kpp_init(struct kcapi_handle **handle, const char *ciphername,
 		   uint32_t flags)
 {
@@ -33,13 +32,11 @@ int kcapi_kpp_init(struct kcapi_handle **handle, const char *ciphername,
 	return 0;
 }
 
-DSO_PUBLIC
 void kcapi_kpp_destroy(struct kcapi_handle *handle)
 {
 	_kcapi_handle_destroy(handle);
 }
 
-DSO_PUBLIC
 int kcapi_kpp_dh_setparam_pkcs3(struct kcapi_handle *handle,
 				const uint8_t *pkcs3, uint32_t pkcs3len)
 {
@@ -51,7 +48,6 @@ int kcapi_kpp_dh_setparam_pkcs3(struct kcapi_handle *handle,
 	return (ret >= 0) ? ret : -errno;
 }
 
-DSO_PUBLIC
 int kcapi_kpp_ecdh_setcurve(struct kcapi_handle *handle,
 			    unsigned long curve_id)
 {
@@ -65,7 +61,6 @@ int kcapi_kpp_ecdh_setcurve(struct kcapi_handle *handle,
 	return (ret >= 0) ? ret : -errno;
 }
 
-DSO_PUBLIC
 int kcapi_kpp_setkey(struct kcapi_handle *handle,
 		     const uint8_t *key, uint32_t keylen)
 {

--- a/lib/kcapi-md.c
+++ b/lib/kcapi-md.c
@@ -21,20 +21,17 @@
 #include "internal.h"
 #include "kcapi.h"
 
-DSO_PUBLIC
 int kcapi_md_init(struct kcapi_handle **handle, const char *ciphername,
 		  uint32_t flags)
 {
 	return _kcapi_handle_init(handle, "hash", ciphername, flags);
 }
 
-DSO_PUBLIC
 void kcapi_md_destroy(struct kcapi_handle *handle)
 {
 	_kcapi_handle_destroy(handle);
 }
 
-DSO_PUBLIC
 int kcapi_md_setkey(struct kcapi_handle *handle,
 		    const uint8_t *key, uint32_t keylen)
 {
@@ -69,7 +66,6 @@ static inline ssize_t _kcapi_md_update(struct kcapi_handle *handle,
 	return 0;
 }
 
-DSO_PUBLIC
 ssize_t kcapi_md_update(struct kcapi_handle *handle,
 			const uint8_t *buffer, size_t len)
 {
@@ -133,7 +129,6 @@ int32_t orig_md_digest(struct kcapi_handle *handle,
 	return (int32_t)impl_md_digest(handle, in, inlen, out, outlen);
 }
 
-DSO_PUBLIC
 uint32_t kcapi_md_digestsize(struct kcapi_handle *handle)
 {
 	struct kcapi_handle_tfm *tfm = handle->tfm;
@@ -141,7 +136,6 @@ uint32_t kcapi_md_digestsize(struct kcapi_handle *handle)
 	return tfm->info.hash_digestsize;
 }
 
-DSO_PUBLIC
 uint32_t kcapi_md_blocksize(struct kcapi_handle *handle)
 {
 	struct kcapi_handle_tfm *tfm = handle->tfm;

--- a/lib/kcapi-rng.c
+++ b/lib/kcapi-rng.c
@@ -28,20 +28,17 @@
 #include "internal.h"
 #include "kcapi.h"
 
-DSO_PUBLIC
 int kcapi_rng_init(struct kcapi_handle **handle, const char *ciphername,
 		   uint32_t flags)
 {
 	return _kcapi_handle_init(handle, "rng", ciphername, flags);
 }
 
-DSO_PUBLIC
 void kcapi_rng_destroy(struct kcapi_handle *handle)
 {
 	_kcapi_handle_destroy(handle);
 }
 
-DSO_PUBLIC
 int kcapi_rng_seed(struct kcapi_handle *handle, uint8_t *seed,
 		   uint32_t seedlen)
 {
@@ -81,7 +78,6 @@ int32_t orig_rng_generate(struct kcapi_handle *handle,
 	return (int32_t)impl_rng_generate(handle, buffer, len);
 }
 
-DSO_PUBLIC
 uint32_t kcapi_rng_seedsize(struct kcapi_handle *handle)
 {
 	struct kcapi_handle_tfm *tfm = handle->tfm;

--- a/lib/kcapi-sym.c
+++ b/lib/kcapi-sym.c
@@ -21,20 +21,17 @@
 #include "internal.h"
 #include "kcapi.h"
 
-DSO_PUBLIC
 int kcapi_cipher_init(struct kcapi_handle **handle, const char *ciphername,
 		      uint32_t flags)
 {
 	return _kcapi_handle_init(handle, "skcipher", ciphername, flags);
 }
 
-DSO_PUBLIC
 void kcapi_cipher_destroy(struct kcapi_handle *handle)
 {
 	_kcapi_handle_destroy(handle);
 }
 
-DSO_PUBLIC
 int kcapi_cipher_setkey(struct kcapi_handle *handle,
 			const uint8_t *key, uint32_t keylen)
 {
@@ -282,7 +279,6 @@ int32_t orig_cipher_stream_op(struct kcapi_handle *handle,
 	return (int32_t)impl_cipher_stream_op(handle, iov, iovlen);
 }
 
-DSO_PUBLIC
 uint32_t kcapi_cipher_ivsize(struct kcapi_handle *handle)
 {
 	struct kcapi_handle_tfm *tfm = handle->tfm;
@@ -290,7 +286,6 @@ uint32_t kcapi_cipher_ivsize(struct kcapi_handle *handle)
 	return tfm->info.ivsize;
 }
 
-DSO_PUBLIC
 uint32_t kcapi_cipher_blocksize(struct kcapi_handle *handle)
 {
 	struct kcapi_handle_tfm *tfm = handle->tfm;

--- a/lib/kcapi-utils.c
+++ b/lib/kcapi-utils.c
@@ -21,13 +21,11 @@
 #include "internal.h"
 #include "kcapi.h"
 
-DSO_PUBLIC
 void kcapi_set_verbosity(enum kcapi_verbosity level)
 {
 	kcapi_verbosity_level = level;
 }
 
-DSO_PUBLIC
 void kcapi_versionstring(char *buf, uint32_t buflen)
 {
 	snprintf(buf, buflen, "libkcapi%s%d.%d.%.f",
@@ -36,7 +34,6 @@ void kcapi_versionstring(char *buf, uint32_t buflen)
 		 KCAPI_MAJVERSION, KCAPI_MINVERSION, (double)KCAPI_PATCHLEVEL);
 }
 
-DSO_PUBLIC
 uint32_t kcapi_version(void)
 {
 	uint32_t version = 0;
@@ -48,7 +45,6 @@ uint32_t kcapi_version(void)
 	return version;
 }
 
-DSO_PUBLIC
 int kcapi_pad_iv(struct kcapi_handle *handle,
 		 const uint8_t *iv, uint32_t ivlen,
 		 uint8_t **newiv, uint32_t *newivlen)
@@ -72,7 +68,6 @@ int kcapi_pad_iv(struct kcapi_handle *handle,
 	return 0;
 }
 
-DSO_PUBLIC
 int kcapi_set_maxsplicesize(struct kcapi_handle *handle, unsigned int size)
 {
 	int ret;
@@ -106,7 +101,6 @@ err:
 	return ret;
 }
 
-DSO_PUBLIC
 int kcapi_get_maxsplicesize(struct kcapi_handle *handle)
 {
 	unsigned int pagesize = (unsigned int)sysconf(_SC_PAGESIZE);


### PR DESCRIPTION
The 1.3.1 release seem to be breaking -flto builds, as the compiler does not understand the symbols when they are forced via __asm__ statements.

Using the new __symver__ attribute fixes symbol version usage with lto builds, but requires gcc >= 10

This patch retains compatbility with gcc > 4 by using the existing macros if gcc < 10 is used.

Note that the second patch is not necessary to fix LTO, but it seemed a good cleanup.