### PR TITLE
Makefile.am: drop -Werror

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -2,7 +2,7 @@ ACLOCAL_AMFLAGS = -I m4
 AUTOMAKE_OPTIONS = subdir-objects
 lib_LTLIBRARIES = libkcapi.la
 
-COMMON_CPPFLAGS = -Wextra -Wall -pedantic -fwrapv --param ssp-buffer-size=4 -O2 -Werror -std=gnu99 -Wconversion
+COMMON_CPPFLAGS = -Wextra -Wall -pedantic -fwrapv --param ssp-buffer-size=4 -O2 -std=gnu99 -Wconversion
 COMMON_LDFLAGS =  -Wl,-z,relro,-z,now
 
 libtool: $(LIBTOOL_DEPS)


### PR DESCRIPTION
Drop -Werror to avoid the following build failure with gcc 9:

```
lib/kcapi-kernel-if.c: In function ‘_kcapi_common_send_meta’:
lib/kcapi-kernel-if.c:173:19: error: conversion to ‘int’ from ‘size_t’ {aka ‘unsigned int’} may change the sign of the result [-Werror=sign-conversion]
  173 |  msg.msg_iovlen = iovlen;
      |                   ^~~~~~
lib/kcapi-kernel-if.c: In function ‘_kcapi_common_send_data’:
lib/kcapi-kernel-if.c:247:19: error: conversion to ‘int’ from ‘size_t’ {aka ‘unsigned int’} may change the sign of the result [-Werror=sign-conversion]
  247 |  msg.msg_iovlen = iovlen;
      |                   ^~~~~~
lib/kcapi-kernel-if.c: In function ‘_kcapi_common_recv_data’:
lib/kcapi-kernel-if.c:545:19: error: conversion to ‘int’ from ‘size_t’ {aka ‘unsigned int’} may change the sign of the result [-Werror=sign-conversion]
  545 |  msg.msg_iovlen = iovlen;
      |                   ^~~~~~
```

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>