### PR TITLE
Add Support for the kcapi_rng_setentropy API

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -10,7 +10,7 @@ dnl KCAPI_PATCHLEVEL API / ABI compatible, no functional changes, no
 dnl 		     enhancements, bug fixes only. Versions with
 dnl		     a decimal point are pre-releases.
 m4_define([__KCAPI_MAJVERSION], [1])
-m4_define([__KCAPI_MINVERSION], [4])
+m4_define([__KCAPI_MINVERSION], [5])
 m4_define([__KCAPI_PATCHLEVEL], [0])
 m4_define([KCAPI_VERSION], [__KCAPI_MAJVERSION.__KCAPI_MINVERSION.__KCAPI_PATCHLEVEL])
 

--- a/lib/internal.h
+++ b/lib/internal.h
@@ -52,14 +52,17 @@ extern "C"
 #ifndef ALG_SET_AEAD_AUTHSIZE
 #define ALG_SET_AEAD_AUTHSIZE		5
 #endif
+#ifndef ALG_SET_DRBG_ENTROPY
+#define ALG_SET_DRBG_ENTROPY		6
+#endif
 #ifndef ALG_SET_PUBKEY
-#define ALG_SET_PUBKEY			6
+#define ALG_SET_PUBKEY			7
 #endif
 #ifndef ALG_SET_DH_PARAMETERS
-#define ALG_SET_DH_PARAMETERS		7
+#define ALG_SET_DH_PARAMETERS		8
 #endif
 #ifndef ALG_SET_ECDH_CURVE
-#define ALG_SET_ECDH_CURVE		8
+#define ALG_SET_ECDH_CURVE		9
 #endif
 
 
@@ -293,6 +296,8 @@ int _kcapi_handle_init(struct kcapi_handle **caller, const char *type,
 void _kcapi_handle_destroy(struct kcapi_handle *handle);
 int _kcapi_common_setkey(struct kcapi_handle *handle, const uint8_t *key,
 			 uint32_t keylen);
+int _kcapi_common_setentropy(struct kcapi_handle *handle, const uint8_t *ent,
+			     uint32_t entlen);
 ssize_t _kcapi_cipher_crypt(struct kcapi_handle *handle, const uint8_t *in,
 			    size_t inlen, uint8_t *out, size_t outlen,
 			    int access, unsigned int enc);

--- a/lib/kcapi-kernel-if.c
+++ b/lib/kcapi-kernel-if.c
@@ -622,6 +622,22 @@ int _kcapi_common_setkey(struct kcapi_handle *handle,
 	return ret;
 }
 
+int _kcapi_common_setentropy(struct kcapi_handle *handle,
+			     const uint8_t *ent, uint32_t entlen)
+{
+	struct kcapi_handle_tfm *tfm = handle->tfm;
+	int ret;
+
+	ret = setsockopt(tfm->tfmfd, SOL_ALG, ALG_SET_DRBG_ENTROPY, ent,
+			 entlen);
+	if (ret < 0)
+		ret = -errno;
+	kcapi_dolog(KCAPI_LOG_DEBUG,
+		    "AF_ALG setentropy: setsockopt syscall returned %d", ret);
+
+	return ret;
+}
+
 static int __kcapi_common_getinfo(struct kcapi_handle *handle,
 				  const char *ciphername,
 				  int drivername)

--- a/lib/kcapi-rng.c
+++ b/lib/kcapi-rng.c
@@ -47,6 +47,14 @@ int kcapi_rng_seed(struct kcapi_handle *handle, uint8_t *seed,
 	return _kcapi_common_setkey(handle, seed, seedlen);
 }
 
+int kcapi_rng_setentropy(struct kcapi_handle *handle, uint8_t *ent,
+			 uint32_t entlen)
+{
+	kcapi_dolog(KCAPI_LOG_VERBOSE,
+		    "Set %u bytes of initial entropy of DRBG");
+	return _kcapi_common_setentropy(handle, ent, entlen);
+}
+
 IMPL_SYMVER(rng_generate, "1.3.1")
 ssize_t impl_rng_generate(struct kcapi_handle *handle,
 			  uint8_t *buffer, size_t len)

--- a/lib/kcapi.h
+++ b/lib/kcapi.h
@@ -1784,6 +1784,26 @@ int kcapi_rng_seed(struct kcapi_handle *handle, uint8_t *seed,
 		   uint32_t seedlen);
 
 /**
+ * kcapi_rng_setentropy() - set the initial entropy of the RNG
+ *
+ * @handle: [in] cipher handle
+ * @ent: [in] entropy data
+ * @entlen: [in] size of entropy
+ *
+ * Note, this call must be called to initialize the selected RNG. When the
+ * SP800-90A DRBG is used, this call causes the DRBG to seed itself from the
+ * provided data in 'ent'.
+ *
+ * Note, in case of using the SP800-90A DRBG, the CRYPTO_USER_API_RNG_CAVP
+ * kernel config knob must be set to 'y' to use this API.
+ *
+ * @return 0 upon success;
+ * 	   a negative errno-style error code if an error occurred
+ */
+int kcapi_rng_setentropy(struct kcapi_handle *handle, uint8_t *ent,
+			 uint32_t entlen);
+
+/**
  * kcapi_rng_generate() - generate a random number
  *
  * @handle: [in] cipher handle

--- a/lib/kcapi.h
+++ b/lib/kcapi.h
@@ -1804,6 +1804,25 @@ int kcapi_rng_setentropy(struct kcapi_handle *handle, uint8_t *ent,
 			 uint32_t entlen);
 
 /**
+ * kcapi_rng_setaddtl() - send additional data to the RNG
+ *
+ * @handle: [in] cipher handle
+ * @addtl: [in] additional data to be sent
+ * @len: [in] size of additional data
+ *
+ * Note, this call must be called immediately prior to calling kcapi_rng_generate
+ * in order to send additional data to be consumed by the RNG.
+ *
+ * Note, in case of using the SP800-90A DRBG, the CRYPTO_USER_API_RNG_CAVP
+ * kernel config knob must be set to 'y' to use this API.
+ *
+ * @return 0 upon success;
+ * 	   a negative errno-style error code if an error occurred
+ */
+int kcapi_rng_setaddtl(struct kcapi_handle *handle, uint8_t *addtl,
+		       uint32_t len);
+
+/**
  * kcapi_rng_generate() - generate a random number
  *
  * @handle: [in] cipher handle

--- a/lib/version.lds
+++ b/lib/version.lds
@@ -240,3 +240,7 @@ LIBKCAPI_1.4.0 {
 	kcapi_cipher_enc_sm4_ctr;
 	kcapi_cipher_dec_sm4_ctr;
 } LIBKCAPI_1.3.1;
+
+LIBKCAPI_1.5.0 {
+	kcapi_rng_setentropy;
+} LIBKCAPI_1.4.0;

--- a/lib/version.lds
+++ b/lib/version.lds
@@ -242,5 +242,6 @@ LIBKCAPI_1.4.0 {
 } LIBKCAPI_1.3.1;
 
 LIBKCAPI_1.5.0 {
+	kcapi_rng_setaddtl;
 	kcapi_rng_setentropy;
 } LIBKCAPI_1.4.0;


### PR DESCRIPTION
Hi Mr Mueller,

My name is Puru and I am working on writing an ACVP harness for the linux kernel
in rust. I have created Rust bindings for your libkcapi library (puru1761/libkcapi) and
I am using these bindings for this purpose. I saw that there is no ability to perform
SP800-90A DRBG testing using the existing libkcapi API. Since 5.10 the linux kernel
hash provided the ability to perform CAVP testing from userspace using the
AF_ALG sock API.

I am submitting this pull request to add support for the kcapi_rng_setentropy()
API, which will in-turn call setentropy in algif_rng.c

Please see these changes that I have submitted below, and consider merge-ing
them into your repository.

Many Thanks,
Puru

The kernel config option CONFIG_CRYPTO_USER_API_RNG_CAVP was
introduced to the linux kernel in version 5.10 and can be used
to perform CAVP testing on the kernel DRBGs. This allows the
DRBGs to be tested from user-space and therefore the ability
to set the initial entropy of the DRBG could be a useful addition
to this library.

This change:

* Adds support for the kcapi_rng_setentropy API
* Adds the required logic in kernel-if to use the socket option
  to set the DRBG's entropy.
* Changes the values for ALG_SET_PUBKEY, et. al. to accomodate
  the ALG_SET_DRBG_ENTROPY socket option
* Adds a private _kcapi_common_setentropy API

Signed-off-by: Puru Kulkarni <puruk@protonmail.com>