### PR TITLE
Add HW Ciphers for CAAM (i.MX6/7/8), ARM Crypto Extension Ciphers & STM32 hardware ciphers

### DIFF
--- a/speed-test/cryptoperf-aead.c
+++ b/speed-test/cryptoperf-aead.c
@@ -352,6 +352,14 @@ static const struct cp_aead_tests testcases[] = {
 	{ "AES(CAAM) GCM(CAAM) 128", "gcm-aes-caam", 16, 16, 0 },
 	{ "AES(CAAM) GCM(CAAM) 192", "gcm-aes-caam", 24, 16, 0 },
 	{ "AES(CAAM) GCM(CAAM) 256", "gcm-aes-caam", 32, 16, 0 },
+
+	{ "AES(STM32) GCM(STM32) 128", "stm32-gcm-aes", 16, 16, 0 },
+	{ "AES(STM32) GCM(STM32) 192", "stm32-gcm-aes", 24, 16, 0 },
+	{ "AES(STM32) GCM(STM32) 256", "stm32-gcm-aes", 32, 16, 0 },
+
+	{ "AES(STM32) CCM(STM32) 128", "stm32-ccm-aes", 16, 16, 1 },
+	{ "AES(STM32) CCM(STM32) 192", "stm32-ccm-aes", 24, 16, 1 },
+	{ "AES(STM32) CCM(STM32) 256", "stm32-ccm-aes", 32, 16, 1 },
 };
 
 static struct cp_test cp_aead_testdef[(2 * (ARRAY_SIZE(testcases)))];

--- a/speed-test/cryptoperf-aead.c
+++ b/speed-test/cryptoperf-aead.c
@@ -348,6 +348,10 @@ static const struct cp_aead_tests testcases[] = {
 	{ "SM4(G) CCM(G)", "ccm(sm4-generic)", 16, 16, 0 },
 	{ "SM4(AVX) CCM(G)", "ccm(sm4-aesni-avx)", 16, 16, 0 },
 	{ "SM4(AVX2) CCM(G)", "ccm(sm4-aesni-avx2)", 16, 16, 0 },
+
+	{ "AES(CAAM) GCM(CAAM) 128", "gcm-aes-caam", 16, 16, 0 },
+	{ "AES(CAAM) GCM(CAAM) 192", "gcm-aes-caam", 24, 16, 0 },
+	{ "AES(CAAM) GCM(CAAM) 256", "gcm-aes-caam", 32, 16, 0 },
 };
 
 static struct cp_test cp_aead_testdef[(2 * (ARRAY_SIZE(testcases)))];

--- a/speed-test/cryptoperf-aead.c
+++ b/speed-test/cryptoperf-aead.c
@@ -360,6 +360,14 @@ static const struct cp_aead_tests testcases[] = {
 	{ "AES(STM32) CCM(STM32) 128", "stm32-ccm-aes", 16, 16, 1 },
 	{ "AES(STM32) CCM(STM32) 192", "stm32-ccm-aes", 24, 16, 1 },
 	{ "AES(STM32) CCM(STM32) 256", "stm32-ccm-aes", 32, 16, 1 },
+
+	{ "AES(ARM64 CE) GCM(ARM64 CE) 128", "gcm-aes-ce", 16, 16, 0 },
+	{ "AES(ARM64 CE) GCM(ARM64 CE) 192", "gcm-aes-ce", 24, 16, 0 },
+	{ "AES(ARM64 CE) GCM(ARM64 CE) 256", "gcm-aes-ce", 32, 16, 0 },
+
+	{ "AES(ARM64 CE) CCM(ARM64 CE) 128", "ccm-aes-ce", 16, 16, 1 },
+	{ "AES(ARM64 CE) CCM(ARM64 CE) 192", "ccm-aes-ce", 24, 16, 1 },
+	{ "AES(ARM64 CE) CCM(ARM64 CE) 256", "ccm-aes-ce", 32, 16, 1 },
 };
 
 static struct cp_test cp_aead_testdef[(2 * (ARRAY_SIZE(testcases)))];

--- a/speed-test/cryptoperf-hash.c
+++ b/speed-test/cryptoperf-hash.c
@@ -135,6 +135,10 @@ static const struct cp_hash_tests testcases[] = {
 	{ "SHA-1(MV-CESA)", "mv-sha1", 0 },
 	{ "SHA-256(MV-CESA)", "mv-sha256", 0 },
 
+	{ "SHA-1(CAAM)", "sha1-caam", 0 },
+	{ "SHA-224(CAAM)", "sha224-caam", 0 },
+	{ "SHA-256(CAAM)", "sha256-caam", 0 },
+
 	{ "HMAC SHA-1(G)", "hmac(sha1-generic)", 1 },
 	{ "HMAC SHA-224(G)", "hmac(sha224-generic)", 1 },
 	{ "HMAC SHA-256(G)", "hmac(sha256-generic)", 1 },
@@ -159,11 +163,19 @@ static const struct cp_hash_tests testcases[] = {
 	{ "HMAC SHA-256(MV-CESA)", "mv-hmac-sha256", 1 },
 
 	{ "SM3(G)", "sm3-generic", 0 },
+
+	{ "HMAC SHA-1(CAAM)", "hmac-sha1-caam", 1 },
+	{ "HMAC SHA-224(CAAM)", "hmac-sha224-caam", 1 },
+	{ "HMAC SHA-224(CAAM)", "hmac-sha224-caam", 1 },
+
 	{ "MD5(G)", "md5-generic", 0 },
 	{ "MD5(MV-CESA)", "mv-md5", 0 },
 	{ "HMAC SM3(G)", "hmac(sm3-generic)", 1 },
 	{ "HMAC MD5(G)", "hmac(md5-generic)", 1 },
 	{ "HMAC MD5(MV-CESA)", "mv-hmac-md5", 1 },
+
+	{ "MD5(CAAM)", "md5-caam", 0 },
+	{ "HMAC MD5(CAAM)", "hmac-md5-caam", 1 },
 };
 
 static struct cp_test cp_hash_testdef[(ARRAY_SIZE(testcases))];

--- a/speed-test/cryptoperf-hash.c
+++ b/speed-test/cryptoperf-hash.c
@@ -139,6 +139,10 @@ static const struct cp_hash_tests testcases[] = {
 	{ "SHA-224(CAAM)", "sha224-caam", 0 },
 	{ "SHA-256(CAAM)", "sha256-caam", 0 },
 
+	{ "SHA-1(STM32)", "stm32-sha1", 0 },
+	{ "SHA-224(STM32)", "stm32-sha224", 0 },
+	{ "SHA-256(STM32)", "stm32-sha256", 0 },
+
 	{ "HMAC SHA-1(G)", "hmac(sha1-generic)", 1 },
 	{ "HMAC SHA-224(G)", "hmac(sha224-generic)", 1 },
 	{ "HMAC SHA-256(G)", "hmac(sha256-generic)", 1 },
@@ -168,6 +172,10 @@ static const struct cp_hash_tests testcases[] = {
 	{ "HMAC SHA-224(CAAM)", "hmac-sha224-caam", 1 },
 	{ "HMAC SHA-224(CAAM)", "hmac-sha224-caam", 1 },
 
+	{ "HMAC SHA-1(STM32)", "stm32-hmac-sha1", 1 },
+	{ "HMAC SHA-224(STM32)", "stm32-hmac-sha224", 1 },
+	{ "HMAC SHA-256(STM32)", "stm32-hmac-sha256", 1 },
+
 	{ "MD5(G)", "md5-generic", 0 },
 	{ "MD5(MV-CESA)", "mv-md5", 0 },
 	{ "HMAC SM3(G)", "hmac(sm3-generic)", 1 },
@@ -176,6 +184,9 @@ static const struct cp_hash_tests testcases[] = {
 
 	{ "MD5(CAAM)", "md5-caam", 0 },
 	{ "HMAC MD5(CAAM)", "hmac-md5-caam", 1 },
+
+	{ "MD5(STM32)", "stm32-md5", 0 },
+	{ "HMAC MD5(STM32)", "stm32-hmac-md5", 1 },
 };
 
 static struct cp_test cp_hash_testdef[(ARRAY_SIZE(testcases))];

--- a/speed-test/cryptoperf-hash.c
+++ b/speed-test/cryptoperf-hash.c
@@ -143,6 +143,10 @@ static const struct cp_hash_tests testcases[] = {
 	{ "SHA-224(STM32)", "stm32-sha224", 0 },
 	{ "SHA-256(STM32)", "stm32-sha256", 0 },
 
+	{ "SHA-1(ARM64 CE)", "sha1-ce", 0 },
+	{ "SHA-224(ARM64 CE)", "sha224-ce", 0 },
+	{ "SHA-256(ARM64 CE)", "sha256-ce", 0 },
+
 	{ "HMAC SHA-1(G)", "hmac(sha1-generic)", 1 },
 	{ "HMAC SHA-224(G)", "hmac(sha224-generic)", 1 },
 	{ "HMAC SHA-256(G)", "hmac(sha256-generic)", 1 },

--- a/speed-test/cryptoperf-skcipher.c
+++ b/speed-test/cryptoperf-skcipher.c
@@ -209,6 +209,10 @@ static const struct cp_skcipher_tests testcases[] = {
 	{ "AES(CAAM) CBC(CAAM) 192", "cbc-aes-caam", 24 },
 	{ "AES(CAAM) CBC(CAAM) 256", "cbc-aes-caam", 32 },
 
+	{ "AES(STM32) CBC(STM32) 128", "stm32-cbc-aes", 16 },
+	{ "AES(STM32) CBC(STM32) 192", "stm32-cbc-aes", 24 },
+	{ "AES(STM32) CBC(STM32) 256", "stm32-cbc-aes", 32 },
+
 	{ "AES(MV-CESA) CBC(MV-CESA) 128", "mv-cbc-aes", 16 },
 	{ "AES(MV-CESA) CBC(MV-CESA) 192", "mv-cbc-aes", 24 },
 	{ "AES(MV-CESA) CBC(MV-CESA) 256", "mv-cbc-aes", 32 },
@@ -233,6 +237,10 @@ static const struct cp_skcipher_tests testcases[] = {
 	{ "AES(CAAM) CTR(CAAM) 128", "ctr-aes-caam", 16 },
 	{ "AES(CAAM) CTR(CAAM) 192", "ctr-aes-caam", 24 },
 	{ "AES(CAAM) CTR(CAAM) 256", "ctr-aes-caam", 32 },
+
+	{ "AES(STM32) CTR(STM32) 128", "stm32-ctr-aes", 16 },
+	{ "AES(STM32) CTR(STM32) 192", "stm32-ctr-aes", 24 },
+	{ "AES(STM32) CTR(STM32) 256", "stm32-ctr-aes", 32 },
 
 	{ "AES(G) XTS(G) 128", "xts(aes-generic)", 32 },
 	{ "AES(G) XTS(G) 192", "xts(aes-generic)", 48 },
@@ -279,6 +287,10 @@ static const struct cp_skcipher_tests testcases[] = {
 	{ "AES(CAAM) ECB(CAAM) 128", "ecb-aes-caam", 16 },
 	{ "AES(CAAM) ECB(CAAM) 192", "ecb-aes-caam", 24 },
 	{ "AES(CAAM) ECB(CAAM) 256", "ecb-aes-caam", 32 },
+
+	{ "AES(STM32) ECB(STM32) 128", "stm32-ecb-aes", 16 },
+	{ "AES(STM32) ECB(STM32) 192", "stm32-ecb-aes", 24 },
+	{ "AES(STM32) ECB(STM32) 256", "stm32-ecb-aes", 32 },
 
 	{ "DES(MV-CESA) CBC(MV-CESA) 56", "mv-cbc-des", 8 },
 	{ "DES(MV-CESA) ECB(MV-CESA) 56", "mv-ecb-des", 8 },

--- a/speed-test/cryptoperf-skcipher.c
+++ b/speed-test/cryptoperf-skcipher.c
@@ -213,6 +213,10 @@ static const struct cp_skcipher_tests testcases[] = {
 	{ "AES(STM32) CBC(STM32) 192", "stm32-cbc-aes", 24 },
 	{ "AES(STM32) CBC(STM32) 256", "stm32-cbc-aes", 32 },
 
+	{ "AES(ARM64 CE) CBC(ARM64 CE) 128", "cbc-aes-ce", 16 },
+	{ "AES(ARM64 CE) CBC(ARM64 CE) 192", "cbc-aes-ce", 24 },
+	{ "AES(ARM64 CE) CBC(ARM64 CE) 256", "cbc-aes-ce", 32 },
+
 	{ "AES(MV-CESA) CBC(MV-CESA) 128", "mv-cbc-aes", 16 },
 	{ "AES(MV-CESA) CBC(MV-CESA) 192", "mv-cbc-aes", 24 },
 	{ "AES(MV-CESA) CBC(MV-CESA) 256", "mv-cbc-aes", 32 },
@@ -242,6 +246,10 @@ static const struct cp_skcipher_tests testcases[] = {
 	{ "AES(STM32) CTR(STM32) 192", "stm32-ctr-aes", 24 },
 	{ "AES(STM32) CTR(STM32) 256", "stm32-ctr-aes", 32 },
 
+	{ "AES(ARM64 CE) CTR(ARM64 CE) 128", "ctr-aes-ce", 16 },
+	{ "AES(ARM64 CE) CTR(ARM64 CE) 192", "ctr-aes-ce", 24 },
+	{ "AES(ARM64 CE) CTR(ARM64 CE) 256", "ctr-aes-ce", 32 },
+
 	{ "AES(G) XTS(G) 128", "xts(aes-generic)", 32 },
 	{ "AES(G) XTS(G) 192", "xts(aes-generic)", 48 },
 	{ "AES(G) XTS(G) 256", "xts(aes-generic)", 64 },
@@ -254,6 +262,10 @@ static const struct cp_skcipher_tests testcases[] = {
 	{ "AES(i586) XTS(G) 128", "xts(aes-asm)", 32 },
 	{ "AES(i586) XTS(G) 192", "xts(aes-asm)", 48 },
 	{ "AES(i586) XTS(G) 256", "xts(aes-asm)", 64 },
+
+	{ "AES(ARM64 CE) XTS(ARM64 CE) 128", "xts-aes-ce", 32 },
+	{ "AES(ARM64 CE) XTS(ARM64 CE) 192", "xts-aes-ce", 48 },
+	{ "AES(ARM64 CE) XTS(ARM64 CE) 256", "xts-aes-ce", 64 },
 
 	{ "AES(G) LRW(G) 128", "lrw(aes-generic)", 32 },
 	{ "AES(G) LRW(G) 192", "lrw(aes-generic)", 40 },
@@ -291,6 +303,10 @@ static const struct cp_skcipher_tests testcases[] = {
 	{ "AES(STM32) ECB(STM32) 128", "stm32-ecb-aes", 16 },
 	{ "AES(STM32) ECB(STM32) 192", "stm32-ecb-aes", 24 },
 	{ "AES(STM32) ECB(STM32) 256", "stm32-ecb-aes", 32 },
+
+	{ "AES(ARM64 CE) ECB(ARM64 CE) 128", "ecb-aes-ce", 16 },
+	{ "AES(ARM64 CE) ECB(ARM64 CE) 192", "ecb-aes-ce", 24 },
+	{ "AES(ARM64 CE) ECB(ARM64 CE) 256", "ecb-aes-ce", 32 },
 
 	{ "DES(MV-CESA) CBC(MV-CESA) 56", "mv-cbc-des", 8 },
 	{ "DES(MV-CESA) ECB(MV-CESA) 56", "mv-ecb-des", 8 },

--- a/speed-test/cryptoperf-skcipher.c
+++ b/speed-test/cryptoperf-skcipher.c
@@ -205,6 +205,10 @@ static const struct cp_skcipher_tests testcases[] = {
 	{ "AES(i586) CBC(G) 192", "cbc(aes-asm)", 24 },
 	{ "AES(i586) CBC(G) 256", "cbc(aes-asm)", 32 },
 
+	{ "AES(CAAM) CBC(CAAM) 128", "cbc-aes-caam", 16 },
+	{ "AES(CAAM) CBC(CAAM) 192", "cbc-aes-caam", 24 },
+	{ "AES(CAAM) CBC(CAAM) 256", "cbc-aes-caam", 32 },
+
 	{ "AES(MV-CESA) CBC(MV-CESA) 128", "mv-cbc-aes", 16 },
 	{ "AES(MV-CESA) CBC(MV-CESA) 192", "mv-cbc-aes", 24 },
 	{ "AES(MV-CESA) CBC(MV-CESA) 256", "mv-cbc-aes", 32 },
@@ -225,6 +229,10 @@ static const struct cp_skcipher_tests testcases[] = {
 	{ "AES(i586) CTR(G) 128", "ctr(aes-asm)", 16 },
 	{ "AES(i586) CTR(G) 192", "ctr(aes-asm)", 24 },
 	{ "AES(i586) CTR(G) 256", "ctr(aes-asm)", 32 },
+
+	{ "AES(CAAM) CTR(CAAM) 128", "ctr-aes-caam", 16 },
+	{ "AES(CAAM) CTR(CAAM) 192", "ctr-aes-caam", 24 },
+	{ "AES(CAAM) CTR(CAAM) 256", "ctr-aes-caam", 32 },
 
 	{ "AES(G) XTS(G) 128", "xts(aes-generic)", 32 },
 	{ "AES(G) XTS(G) 192", "xts(aes-generic)", 48 },
@@ -267,6 +275,10 @@ static const struct cp_skcipher_tests testcases[] = {
 	{ "AES(MV-CESA) ECB(MV-CESA) 128", "mv-ecb-aes", 16 },
 	{ "AES(MV-CESA) ECB(MV-CESA) 192", "mv-ecb-aes", 24 },
 	{ "AES(MV-CESA) ECB(MV-CESA) 256", "mv-ecb-aes", 32 },
+
+	{ "AES(CAAM) ECB(CAAM) 128", "ecb-aes-caam", 16 },
+	{ "AES(CAAM) ECB(CAAM) 192", "ecb-aes-caam", 24 },
+	{ "AES(CAAM) ECB(CAAM) 256", "ecb-aes-caam", 32 },
 
 	{ "DES(MV-CESA) CBC(MV-CESA) 56", "mv-cbc-des", 8 },
 	{ "DES(MV-CESA) ECB(MV-CESA) 56", "mv-ecb-des", 8 },


### PR DESCRIPTION
These have all been tested on real hardware.