### PR TITLE
kcapi-hasher ship the multi-call binary

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -166,9 +166,8 @@ CHECK_DIR_BIN_FC = $(if $(CHECK_DIR),$(CHECK_DIR)/fipscheck,$(bindir))
 CHECK_DIR_BIN_HC = $(if $(CHECK_DIR),$(CHECK_DIR)/hmaccalc,$(bindir))
 
 install-exec-hook:
-	(cd $(DESTDIR)$(bindir) && \
-	($(foreach link, $(hasher_links), $(LN) -f kcapi-hasher $(link);)))
-	-rm -f $(DESTDIR)$(bindir)/kcapi-hasher
+	$(MKDIR_P) -p $(DESTDIR)/$(pkglibexecdir)
+	$(foreach link, $(hasher_links), $(LN) -srf $(DESTDIR)/$(bindir)/kcapi-hasher $(DESTDIR)/$(pkglibexecdir)/$(link);)
 if HAVE_OPENSSL
 	$(MKDIR_P) $(DESTDIR)$(CHECK_DIR_BIN_FC)
 	$(MKDIR_P) $(DESTDIR)$(CHECK_DIR_BIN_HC)


### PR DESCRIPTION
Ship the kcapi-hasher multi-call binary, and install symbolic relative symlinks to it in the libexec directory. This is packaging policy compliant with all major Linux distributions (they shun hard links). And this allows for libkcapi tools to co-exist and be co-installed with coreutils / rust-coreutils / openssl / etc implementations. Installing kcapi-hasher utility directly makes it more accessible and more useful in many context when one wants to compare and examine kcapi-hasher implementation with other ones.

Users that want to prefer the libkcapi implementation can prepend the libexec location to their PATH.