### PR TITLE
tests: fix overly-optimistic kernel version checks

### DIFF
--- a/test/test.sh
+++ b/test/test.sh
@@ -1560,7 +1560,8 @@ else
 	echo_deact "AEAD tests of copied AAD deactivated"
 fi
 
-if $(check_min_kernelver 5 99); then
+# TODO add version check when supported upstream
+if false; then
 	asymfunc 4
 	asymfunc 4 -s
 	asymfunc 4 -v
@@ -1583,7 +1584,8 @@ else
 	echo_deact "All asymmetric tests deactivated"
 fi
 
-if $(check_min_kernelver 5 99); then
+# TODO add version check when supported upstream
+if false; then
 	kppfunc 13
 	kppfunc 13 X -m
 	kppfunc 13 -v


### PR DESCRIPTION
The mainline kernel is now at version 6.0 so these >= 5.99 checks are
now incorrectly enabling tests that don't work. Instead of bumping the
imaginary version and face the same problem again in a couple years,
replace the checks with 'false' and a TODO comment.