### PR TITLE
Fix symver build error on non-ELF platforms

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -76,6 +76,8 @@ AX_ADD_FORTIFY_SOURCE
 
 AC_CHECK_API_VERSION
 
+AC_CHECK_ATTRIBUTE_SYMVER
+
 AC_ARG_ENABLE([werror], [AS_HELP_STRING([--disable-werror], [Disable -Werror])], [with_werror=$enableval], [with_werror=yes])
 AM_CONDITIONAL([ENABLE_WERROR], [test "x$with_werror" = "xyes"])
 

--- a/lib/internal.h
+++ b/lib/internal.h
@@ -352,7 +352,7 @@ static inline int io_getevents(__attribute__((unused)) aio_context_t ctx,
  * Auxiliary macros
  ************************************************************/
 
-#if __GNUC__ >= 10
+#if HAVE_ATTRIBUTE_SYMVER && __GNUC__ >= 10
 # define IMPL_SYMVER(name, version) \
     __attribute__((__symver__("kcapi_" #name "@@LIBKCAPI_" version)))
 

--- a/m4/ac_check_attribute_symver.m4
+++ b/m4/ac_check_attribute_symver.m4
@@ -1,0 +1,24 @@
+dnl Check compiler support for symver function attribute
+AC_DEFUN([AC_CHECK_ATTRIBUTE_SYMVER], [
+	saved_CFLAGS=$CFLAGS
+	CFLAGS="-O0 -Werror"
+	AC_COMPILE_IFELSE(
+		[AC_LANG_PROGRAM(
+			[[
+				void _test_attribute_symver(void);
+				__attribute__((__symver__("sym@VER_1.2.3"))) void _test_attribute_symver(void) {}
+			]],
+			[[ 
+				_test_attribute_symver()
+			]]
+		)],
+		[
+			AC_DEFINE([HAVE_ATTRIBUTE_SYMVER], 1, [Define to 1 if __attribute__((symver)) is supported])
+		],
+		[
+			AC_DEFINE([HAVE_ATTRIBUTE_SYMVER], 0, [Define to 0 if __attribute__((symver)) is not supported])
+		]
+	)
+	CFLAGS=$saved_CFLAGS
+])
+


### PR DESCRIPTION
The following error is observed on Microblaze [1] build:
```
error: symver is only supported on ELF platforms
```
due to using __attribute__((symver)) on non-ELF platform. So, revert to using .symver in such case.

[1]: http://autobuild.buildroot.net/results/447/4470efb5a078c0e368f6bd4f5ec455eea5eeebb5/build-end.log

Signed-off-by: Tan En De <ende.tan@starfivetech.com>