### PR TITLE
Append newline to stdout

### DIFF
--- a/apps/kcapi-hasher.c
+++ b/apps/kcapi-hasher.c
@@ -905,12 +905,14 @@ int main(int argc, char *argv[])
 		.bsd_style = 0,
 		.hashlen = 0,
 		.key = KEY_FIPSCHECK,
+		.newline = 1,
 	};
 	const struct hash_params PARAMS_SELF_HMACCALC = {
 		.name = NAMES_SHA512[1],
 		.bsd_style = 0,
 		.hashlen = 0,
 		.key = KEY_HMACCALC,
+		.newline = 1,
 	};
 
 	basec = strdup(argv[0]);


### PR DESCRIPTION
Append newline to stdout for printing hash may be a good experience.
[root@USER libkcapi]# sha256hmac -L
e652726ddb463ac08554ef8c8e0c1c17e62e637b70b2b01545db7cfcb154c869[root@USER libkcapi]# 