### PR TITLE
self-check fails for all binaries and library in master

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -70,6 +70,7 @@ jobs:
           run: |
             autoreconf -i
             ./configure \
+                --prefix=/usr \
                 --enable-kcapi-hasher \
                 --enable-kcapi-test \
                 --enable-kcapi-rngapp \
@@ -79,6 +80,17 @@ jobs:
                 --enable-lib-kpp
         - name: Run build
           run: make -j$(nproc)
+        - name: Run install
+          run: sudo make install
+        - name: Check installed binaries FIPS self-checks
+          env:
+            KCAPI_HASHER_FORCE_FIPS: 1
+          run: |
+            rc=0
+            /usr/bin/kcapi-hasher -n sha512hmac /bin/true || rc=$?
+            /usr/libexec/libkcapi/sha512hmac /bin/true || rc=$?
+            /usr/libexec/libkcapi/fipshmac /bin/true || rc=$?
+            exit $rc
         - name: Run cppcheck
           run: make cppcheck
         - name: Run CLang static analysis

--- a/Makefile.am
+++ b/Makefile.am
@@ -157,31 +157,23 @@ EXTRA_bin_kcapi_hasher_DEPENDENCIES = libtool
 SCAN_FILES += $(bin_kcapi_hasher_SOURCES)
 man_MANS += apps/kcapi-hasher.1
 
-hasher_links_fc = sha1sum sha224sum sha256sum sha384sum sha512sum \
-		  md5sum sm3sum fipscheck fipshmac sha3sum
-hasher_links_hc = sha1hmac sha224hmac sha256hmac sha384hmac sha512hmac sm3hmac
-hasher_links = $(hasher_links_fc) $(hasher_links_hc)
+hasher_links = sha1sum sha224sum sha256sum sha384sum sha512sum md5sum	\
+	sm3sum fipscheck fipshmac sha3sum sha1hmac sha224hmac		\
+	sha256hmac sha384hmac sha512hmac sm3hmac
 
-CHECKSUM_CMD_FC = $(OPENSSL) sha256 -r -hmac orboDeJITITejsirpADONivirpUkvarP
-CHECKSUM_CMD_HC = $(OPENSSL) sha512 -r -hmac FIPS-FTW-RHT2009
+CHECKSUM_CMD = $(OPENSSL) sha512 -r -hmac FIPS-FTW-RHT2009
 
-CHECK_DIR_LIB = $(if $(CHECK_DIR),$(CHECK_DIR)/fipscheck,$(libdir))
-CHECK_DIR_BIN_FC = $(if $(CHECK_DIR),$(CHECK_DIR)/fipscheck,$(bindir))
-CHECK_DIR_BIN_HC = $(if $(CHECK_DIR),$(CHECK_DIR)/hmaccalc,$(bindir))
+CHECK_DIR_LIB = $(if $(CHECK_DIR),$(CHECK_DIR)/hmaccalc,$(libdir))
+CHECK_DIR_BIN = $(if $(CHECK_DIR),$(CHECK_DIR)/hmaccalc,$(bindir))
 
 install-exec-hook:
 	$(MKDIR_P) -p $(DESTDIR)/$(pkglibexecdir)
 	$(foreach link, $(hasher_links), $(LN) -srf $(DESTDIR)/$(bindir)/kcapi-hasher $(DESTDIR)/$(pkglibexecdir)/$(link);)
 if HAVE_OPENSSL
-	$(MKDIR_P) $(DESTDIR)$(CHECK_DIR_BIN_FC)
-	$(MKDIR_P) $(DESTDIR)$(CHECK_DIR_BIN_HC)
-	(cd $(DESTDIR)$(bindir) && \
-	($(foreach link, $(hasher_links_fc), \
-		$(CHECKSUM_CMD_FC) $(link) > $(DESTDIR)$(CHECK_DIR_BIN_FC)/$(CHECK_PREFIX)$(link).$(CHECK_SUFFIX);) \
-	$(foreach link, $(hasher_links_hc), \
-		$(CHECKSUM_CMD_HC) $(link) > $(DESTDIR)$(CHECK_DIR_BIN_HC)/$(CHECK_PREFIX)$(link).$(CHECK_SUFFIX);):))
-	($(foreach lib, $(wildcard $(DESTDIR)$(libdir)/libkcapi.so*), \
-		$(CHECKSUM_CMD_FC) $(lib)  > $(DESTDIR)$(CHECK_DIR_LIB)/$(CHECK_PREFIX)$(notdir $(lib)).$(CHECK_SUFFIX);):)
+	$(MKDIR_P) $(DESTDIR)$(CHECK_DIR_BIN)
+	cd $(DESTDIR)$(bindir) && $(CHECKSUM_CMD) kcapi-hasher > $(DESTDIR)$(CHECK_DIR_BIN)/$(CHECK_PREFIX)kcapi-hasher.$(CHECK_SUFFIX)
+	$(foreach lib, $(wildcard $(DESTDIR)$(libdir)/libkcapi.so*), \
+		$(CHECKSUM_CMD) $(lib)  > $(DESTDIR)$(CHECK_DIR_LIB)/$(CHECK_PREFIX)$(notdir $(lib)).$(CHECK_SUFFIX);)
 endif
 endif
 

--- a/apps/kcapi-hasher.c
+++ b/apps/kcapi-hasher.c
@@ -850,7 +850,6 @@ int main(int argc, char *argv[])
 		.bsd_style = 0,
 		.newline = 1,
 	};
-	const struct hash_params *params_self;
 	char *basec = NULL;
 	const char *basen = NULL;
 	int ret = -EFAULT;
@@ -893,20 +892,6 @@ int main(int argc, char *argv[])
 		{0, 0, 0, 0}
 	};
 
-	/*
-	 * Self-integrity check:
-	 *	* fipscheck/fipshmac and sha*sum equivalents are using the
-	 *	  fipscheck key and hmac(sha256)
-	 *	* hmaccalc applications are using the hmaccalc key and
-	 *	  hmac(sha512)
-	 */
-	const struct hash_params PARAMS_SELF_FIPSCHECK = {
-		.name = NAMES_SHA256[1],
-		.bsd_style = 0,
-		.hashlen = 0,
-		.key = KEY_FIPSCHECK,
-		.newline = 1,
-	};
 	const struct hash_params PARAMS_SELF_HMACCALC = {
 		.name = NAMES_SHA512[1],
 		.bsd_style = 0,
@@ -930,7 +915,6 @@ int main(int argc, char *argv[])
 		optind = 1;
 	opterr = 1;
 
-	params_self = &PARAMS_SELF_FIPSCHECK;
 	if (0 == strncmp(basen, "kcapi-hasher", 12)) {
 		// called directly, hash must be set with -h
 	} else if (0 == strncmp(basen, "sha256sum", 9)) {
@@ -963,32 +947,26 @@ int main(int argc, char *argv[])
 		names = NAMES_SHA1;
 		hmac = 1;
 		params.key = KEY_HMACCALC;
-		params_self = &PARAMS_SELF_HMACCALC;
 	} else if (0 == strncmp(basen, "sha224hmac", 10)) {
 		names = NAMES_SHA224;
 		hmac = 1;
 		params.key = KEY_HMACCALC;
-		params_self = &PARAMS_SELF_HMACCALC;
 	} else if (0 == strncmp(basen, "sha256hmac", 10)) {
 		names = NAMES_SHA256;
 		hmac = 1;
 		params.key = KEY_HMACCALC;
-		params_self = &PARAMS_SELF_HMACCALC;
 	} else if (0 == strncmp(basen, "sha384hmac", 10)) {
 		names = NAMES_SHA384;
 		hmac = 1;
 		params.key = KEY_HMACCALC;
-		params_self = &PARAMS_SELF_HMACCALC;
 	} else if (0 == strncmp(basen, "sha512hmac", 10)) {
 		names = NAMES_SHA512;
 		hmac = 1;
 		params.key = KEY_HMACCALC;
-		params_self = &PARAMS_SELF_HMACCALC;
 	} else if (0 == strncmp(basen, "sm3hmac", 7)) {
 		names = NAMES_SM3;
 		hmac = 1;
 		params.key = KEY_HMACCALC;
-		params_self = &PARAMS_SELF_HMACCALC;
 	} else {
 		fprintf(stderr, "Unknown invocation name: %s\n", basen);
 		usage(argv[0], fipscheck);
@@ -1191,7 +1169,7 @@ int main(int argc, char *argv[])
 	}
 
 	/* library self-check must be consistent across apps: */
-	if (fipscheck_self(params_self, &PARAMS_SELF_FIPSCHECK, selfcheck_mode)) {
+	if (fipscheck_self(&PARAMS_SELF_HMACCALC, &PARAMS_SELF_HMACCALC, selfcheck_mode)) {
 		fprintf(stderr, "Integrity check of application %s failed\n",
 			basen);
 		ret = 1;


### PR DESCRIPTION
Now that all applications are symlinks, they cannot have different self-checks, as they all try to read the same .kcapi-hasher.hmac. This is thus a breaking change as libkcapi.so and most *sums apps will now now perform self-checks using hmaccalc.

If this is not acceptable and previous scheme of using fipscheck for self-check of libkcapi.so fipscheck fipshmac and most other *sum apps is required fipsselfcheck function will need adjustment to read and parse /proc/self/cmdline instead of /proc/self/exe.