### PR TITLE
Remove erroneous HKDF loops check

### DIFF
--- a/test/kcapi-main.c
+++ b/test/kcapi-main.c
@@ -4626,12 +4626,6 @@ static int cavs_hkdf(struct kcapi_cavs *cavs_test, uint32_t loops)
 	size_t mdhexlen = cavs_test->outlen * 2 + 1;
 	ssize_t ret = 1;
 
-	if (!loops) {
-		printf("PBKDF suggested iteration count: %u\n",
-		       kcapi_pbkdf_iteration_count(cavs_test->cipher, 0));
-		return 0;
-	}
-
 	if (cavs_test->aligned) {
 		if (posix_memalign((void *)&outbuf, pagesize, cavs_test->outlen))
 			return -ENOMEM;


### PR DESCRIPTION
HKDF is not supposed to check for the presence of loops, and in fact the test.sh script explicitly does not provide it.