### PR TITLE
Prevent cppcheck from defining CHECK_DIR

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -241,7 +241,7 @@ endif
 
 if HAVE_CPPCHECK
 cppcheck:
-	$(CPPCHECK) --error-exitcode=42 --enable=performance,warning,portability $(sort $(SCAN_FILES))
+	$(CPPCHECK) -U CHECK_DIR --error-exitcode=42 --enable=performance,warning,portability $(sort $(SCAN_FILES))
 endif
 
 if HAVE_MKTEMP


### PR DESCRIPTION
Recent versions of cppcheck fail with a syntax error when they check apps/kcapi-hasher.c with CHECK_DIR defined (probably they now define it to 1 instead of an empty value). To fix it, instruct cppcheck to only check with CHECK_DIR left undefined.

Link: https://bugzilla.redhat.com/show_bug.cgi?id=2225970