### PR TITLE
Disable test of obsolete ansi_cprng in FIPS mode

### DIFF
--- a/test/kcapi-main.c
+++ b/test/kcapi-main.c
@@ -652,8 +652,6 @@ static int is_fips_mode(void)
 static int auxiliary_tests(void)
 {
 	struct kcapi_handle *handle = NULL;
-	const char *ansi_cprng_name = is_fips_mode() ? "fips(ansi_cprng)"
-	                                             : "ansi_cprng";
 	int ret = 0;
 
         if (kcapi_aead_init(&handle, "ccm(aes)", 0)) {
@@ -711,27 +709,28 @@ static int auxiliary_tests(void)
 	if (aux_test_rng("drbg_nopr_ctr_aes256", NULL, 0))
 		ret++;
 
-	/* X9.31 RNG must require seed */
-	printf("X9.31 missing seeding: ");
-	if (!aux_test_rng(ansi_cprng_name, NULL, 0))
-		ret++;
-	/* X9.31 seed too short */
-	printf("X9.31 insufficient seeding: ");
-	if (!aux_test_rng(ansi_cprng_name,
-			  (uint8_t *)
-			  "\x00\x01\x02\x03\x04\x05\x06\x07\x08"
-			  "\x00\x01\x02\x03\x04\x05\x06\x07\x08", 16))
-		ret++;
-	/* X9.31 seed right sized short */
-	if (aux_test_rng(ansi_cprng_name,
-			 (uint8_t *)
-			 "\x00\x01\x02\x03\x04\x05\x06\x07\x08"
-			 "\x00\x01\x02\x03\x04\x05\x06\x07\x08"
-			 "\x00\x01\x02\x03\x04\x05\x06\x07\x08"
-			 "\x00\x01\x02\x03\x04\x05\x06\x07\x08", 32)) {
-		printf("Error for %s: kernel module ansi_cprng present?\n",
-		       ansi_cprng_name);
-		ret++;
+	if (!is_fips_mode()) {
+		/* X9.31 RNG must require seed */
+		printf("X9.31 missing seeding: ");
+		if (!aux_test_rng("ansi_cprng", NULL, 0))
+			ret++;
+		/* X9.31 seed too short */
+		printf("X9.31 insufficient seeding: ");
+		if (!aux_test_rng("ansi_cprng",
+				  (uint8_t *)
+				  "\x00\x01\x02\x03\x04\x05\x06\x07\x08"
+				  "\x00\x01\x02\x03\x04\x05\x06\x07\x08", 16))
+			ret++;
+		/* X9.31 seed right sized short */
+		if (aux_test_rng("ansi_cprng",
+				 (uint8_t *)
+				 "\x00\x01\x02\x03\x04\x05\x06\x07\x08"
+				 "\x00\x01\x02\x03\x04\x05\x06\x07\x08"
+				 "\x00\x01\x02\x03\x04\x05\x06\x07\x08"
+				 "\x00\x01\x02\x03\x04\x05\x06\x07\x08", 32)) {
+			printf("Error for ansi_cprng: kernel module ansi_cprng present?\n");
+			ret++;
+		}
 	}
 
 	return ret;


### PR DESCRIPTION
Auxiliary test fails in FIPS mode due to ansi_cprng being obsolete.
This disables the ansi_cprng test part when FIPS mode is enabled.