### PR TITLE
Adjust kcapi-hasher for FIPS 140-3

### DIFF
--- a/apps/kcapi-hasher.1
+++ b/apps/kcapi-hasher.1
@@ -24,6 +24,7 @@ kcapi-hasher \- Kernel Crypto API Message Digest Check Helper
 .B kcapi-hasher
 [\-n \fI\,BASENAME\/\fR]
 [\fI\,OPTION\/\fR]... \fB\-c\fR FILE
+[\fB\-T\fR FILE]
 
 .B kcapi-hasher
 [\-n \fI\,BASENAME\/\fR]
@@ -70,6 +71,9 @@ Print checksum of the libkcapi library and exit
 .TP
 \fB\-c\fR \fB\-\-check\fR FILE
 Verify hash sums from file
+.TP
+\fB\-T\fR \fB\-\-target\fR FILE
+Override filenames found in hash sums file; use with -c
 .TP
 \fB\-u\fR \fB\-\-unkeyed\fR
 Force unkeyed hash

--- a/apps/kcapi-hasher.c
+++ b/apps/kcapi-hasher.c
@@ -360,6 +360,7 @@ static int hasher(struct kcapi_handle *handle, const struct hash_params *params,
 		if (hashlen > (uint32_t)ret) {
 			fprintf(stderr, "Invalid truncated hash size: %lu > %zd\n",
 			        (unsigned long)hashlen, ret);
+			kcapi_memset_secure(md, 0, sizeof(md));
 			return (int)ret;
 		}
 
@@ -376,6 +377,7 @@ static int hasher(struct kcapi_handle *handle, const struct hash_params *params,
 				ret = 1;
 			else
 				ret = 0;
+			kcapi_memset_secure(compmd, 0, sizeof(compmd));
 		} else {
 			if (outfile == NULL) { /* only print hash (hmaccalc -S) */
 				bin2print(md, hashlen, NULL, stdout,
@@ -396,6 +398,7 @@ static int hasher(struct kcapi_handle *handle, const struct hash_params *params,
 		fprintf(stderr, "Generation of hash for file %s failed (%zd)\n",
 			filename ? filename : "stdin", ret);
 	}
+	kcapi_memset_secure(md, 0, sizeof(md));
 	return (int)ret;
 }
 
@@ -696,6 +699,7 @@ out:
 	if (file)
 		fclose(file);
 	kcapi_md_destroy(handle);
+	kcapi_memset_secure(buf, 0, sizeof(buf));
 
 	/*
 	 * If we found no lines to check, return an error.


### PR DESCRIPTION
- adds zeroisation of temporary values computed during hmac sum check
- adds an option to specify a target file of the hmac sum check