### PR TITLE
kcapi-hasher: fail if -T is used without -c

### DIFF
--- a/apps/kcapi-hasher.c
+++ b/apps/kcapi-hasher.c
@@ -1219,6 +1219,12 @@ int main(int argc, char *argv[])
 		optind++;
 	}
 
+	if (targetfile && !checkfile) {
+		fprintf(stderr, "-T cannot be used without -c\n");
+		ret = 1;
+		goto out;
+	}
+
 	if (!checkfile)
 		ret = hash_files(&params, argv + optind,
 				 (uint32_t)(argc - optind),


### PR DESCRIPTION
New option -T was added recently. It must be used with -c. If used without -c, kcapi-hasher just hangs.

If accepted, feel free to squash it with the original commit  adding -T support (0e3e2032a97c51697a5134ca6eabbd5708e9498a).