### PR TITLE
kcapi: stop testing drbg_nopr_sha1

### DIFF
--- a/test/kcapi-main.c
+++ b/test/kcapi-main.c
@@ -704,8 +704,6 @@ static int auxiliary_tests(void)
 
 	if (aux_test_rng("drbg_nopr_hmac_sha256", NULL, 0))
 		ret++;
-	if (aux_test_rng("drbg_nopr_sha1", NULL, 0))
-		ret++;
 	if (aux_test_rng("drbg_nopr_ctr_aes256", NULL, 0))
 		ret++;
 


### PR DESCRIPTION
As of kernel 6.8 / commit bc197f576002 ("crypto: drbg - Remove SHA1 from drbg") this algorithm has been completely removed and this test would start failing.