### PR TITLE
docproc: guard against overflow

### DIFF
--- a/lib/doc/bin/docproc.c
+++ b/lib/doc/bin/docproc.c
@@ -35,6 +35,7 @@
  */
 
 #define _GNU_SOURCE
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -402,7 +403,8 @@ static void find_all_symbols(char *filename)
 			do {
 				while ((ret = read(pipefd[0],
 						   data + data_len,
-						   4096)) > 0) {
+						   4096)) > 0 &&
+				       data_len <= SIZE_MAX - 4096 - (size_t)ret) {
 					data_len += (size_t)ret;
 					data = realloc(data, data_len + 4096);
 					if (!data) {


### PR DESCRIPTION
Report from static analysis shows a possible overflow. The tainted_data_return is not a problem due to the guard in the loop. But there is no guard against overflow of data_len. I am not sure how relevant this is.

Here is the report:
```
Error: INTEGER_OVERFLOW (CWE-190):
libkcapi-1.4.0/lib/doc/bin/docproc.c:403: tainted_data_return: Called function "read(pipefd[0], data + data_len, 4096UL)", and a possible return value may be less than zero.
libkcapi-1.4.0/lib/doc/bin/docproc.c:403: assign: Assigning: "ret" = "read(pipefd[0], data + data_len, 4096UL)".
libkcapi-1.4.0/lib/doc/bin/docproc.c:406: overflow: The expression "data_len" is considered to have possibly overflowed.
libkcapi-1.4.0/lib/doc/bin/docproc.c:407: overflow: The expression "data_len + 4096UL" is deemed overflowed because at least one of its arguments has overflowed.
libkcapi-1.4.0/lib/doc/bin/docproc.c:407: overflow_sink: "data_len + 4096UL", which might have underflowed, is passed to "realloc(data, data_len + 4096UL)".
#  405|                                                      4096)) > 0) {
#  406|                                           data_len += (size_t)ret;
#  407|->                                         data = realloc(data, data_len + 4096);
#  408|                                           if (!data) {
#  409|                                                   perror("realloc");
```