### PR TITLE
remove DESTDIR from symlink target path

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -168,7 +168,7 @@ CHECK_DIR_BIN = $(if $(CHECK_DIR),$(CHECK_DIR)/hmaccalc,$(bindir))
 
 install-exec-hook:
 	$(MKDIR_P) -p $(DESTDIR)/$(pkglibexecdir)
-	$(foreach link, $(hasher_links), $(LN) -sf $(DESTDIR)/$(bindir)/kcapi-hasher $(DESTDIR)/$(pkglibexecdir)/$(link);)
+	$(foreach link, $(hasher_links), $(LN) -sf $(bindir)/kcapi-hasher $(DESTDIR)/$(pkglibexecdir)/$(link);)
 if HAVE_OPENSSL
 	$(MKDIR_P) $(DESTDIR)$(CHECK_DIR_BIN)
 	cd $(DESTDIR)$(bindir) && $(CHECKSUM_CMD) kcapi-hasher > $(DESTDIR)$(CHECK_DIR_BIN)/$(CHECK_PREFIX)kcapi-hasher.$(CHECK_SUFFIX)


### PR DESCRIPTION
The symlink target should not contain DESTDIR.

Fixes <[805d2dd0bec](https://github.com/smuellerDD/libkcapi/commit/805d2dd0bec9ddb9d714afd4e181cee88c13adb0)> ln does not require -r as absolute path names are given