### PR TITLE
Suppress warnings when FIPS support is not compiled in

### DIFF
--- a/test/test.sh
+++ b/test/test.sh
@@ -557,7 +557,7 @@ KPP_exp_2="78fbd4d1ed7ea6fc8f1e1a6f8a5c750845401589ad3c135088b4ec78f54c57b436d1a
 
 is_fips_enabled()
 {
-	test $(cat /proc/sys/crypto/fips_enabled) = "1"
+	test "$(cat /proc/sys/crypto/fips_enabled 2> /dev/null)" = "1"
 }
 
 # Test required for test with multiple IOVECs on i686


### PR DESCRIPTION
When CONFIG_CRYPTO_FIPS is not enabled in the kernel config, none of the FIPS related sysctl entries exist. In that case, avoid these errors:
- `cat` complains /proc/sys/crypto/fips_enabled does not exist
- `test` complains about a missing operand to the `=` operator